### PR TITLE
fix: config base pash for github page

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,6 @@ name: deploy
 on:
   push:
     branches: [ "main", "dev" ]
-  pull_request:
-    branches: [ "main", "dev" ]
 
 jobs:
   build:
@@ -17,8 +15,6 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
     steps:
       - uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
       - name: Setup Node
         uses: actions/setup-node@v1
         with:
@@ -50,4 +46,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
-

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -20,9 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.head_ref }}
-        token: ${{ secrets.PNPM_ACTION_PAT }}
     - uses: pnpm/action-setup@v2
       with:
         version: 7

--- a/config/vite.config.prod.ts
+++ b/config/vite.config.prod.ts
@@ -11,6 +11,7 @@ import configImageminPlugin from './plugin/imagemin'
 export default mergeConfig(
   {
     mode: 'production',
+    base: '/dashboard/',
     plugins: [
       configCompressPlugin('gzip'),
       configVisualizerPlugin(),


### PR DESCRIPTION
Signed-off-by: Ruihang Xia <waynestxia@gmail.com>

This [github page](https://greptimeteam.github.io/dashboard/) cannot load some resource:

<img width="366" alt="image" src="https://user-images.githubusercontent.com/15380403/210779637-7594014e-3429-4ef2-b40b-7d25990c8fdc.png">

I read this [document](https://vitejs.dev/guide/static-deploy.html#github-pages) and guess I need to config the `base` path.