### PR TITLE
docs: add docker compose sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,26 @@ Dashboard is a data-visualization platform for [GreptimeDB](https://github.com/g
 - Follow [getting started](https://docs.greptime.com/getting-started/overview) to create your table and insert some data
 - Run a `SELECT` query and check the result as table or chart
 
+### Docker
+
+Pre-built docker images are available on docker hub, you can pull latest image
+and run via:
+
+```
+docker pull greptime:greptimedb-dashboard
+docker run \
+  -e GREPTIMEDB_HTTP_HOST=127.0.0.1 \
+  -e GREPTIMEDB_HTTP_PORT=4000 \
+  -e NGINX_PORT=8080 \
+  --network host
+  greptimedb-dashboard:latest
+
+## open your browser at http://localhost:8080/dashboard
+```
+
+To build image by yourself, or use `docker-compose` to setup both greptimedb and
+dashboard, see [instructions here](docker/README.md).
+
 ## Contributing
 
 - Please refer to [contribution guidelines](https://github.com/GreptimeTeam/greptimedb/blob/75dcf2467b022d4378f904efe5aae5027298986e/CONTRIBUTING.md) for more information.

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ Pre-built docker images are available on docker hub, you can pull latest image
 and run via:
 
 ```
-docker pull greptime:greptimedb-dashboard
+docker pull greptime/greptimedb-dashboard
 docker run \
   -e GREPTIMEDB_HTTP_HOST=127.0.0.1 \
   -e GREPTIMEDB_HTTP_PORT=4000 \
   -e NGINX_PORT=8080 \
-  --network host
-  greptimedb-dashboard:latest
+  --network host \
+  greptime/greptimedb-dashboard:latest
 
 ## open your browser at http://localhost:8080/dashboard
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,5 +10,10 @@ RUN pnpm build
 
 FROM nginx:1.23 as base
 
-COPY --from=builder /greptimedb-dashboard/dist/ /usr/share/nginx/html/
+ENV GREPTIMEDB_HTTP_HOST=127.0.0.1
+ENV GREPTIMEDB_HTTP_PORT=4000
+ENV NGINX_PORT=8080
+
+RUN mkdir -p /usr/share/nginx/html/dashboard
+COPY --from=builder /greptimedb-dashboard/dist/ /usr/share/nginx/html/dashboard
 ADD docker/greptimedb.conf /etc/nginx/templates/default.conf.template

--- a/docker/README.md
+++ b/docker/README.md
@@ -27,3 +27,29 @@ docker run \
   --network host
   greptimedb-dashboard:latest
 ```
+
+Open you browser and visit `http://localhost:8080/dashboard`
+
+# Using `docker-compose`
+
+[docker-compose](https://docs.docker.com/compose/) is a light-weighted container
+orchestration solution. We provide a sample compose file to build and run
+dashboard with greptimedb ready.
+
+## Build
+
+Run `docker compose build` from root of the repo:
+
+```
+docker compose -f docker/docker-compose.yml build
+```
+
+## Run
+
+Run `docker compose up` from root of the repo:
+
+```
+docker compose -f docker/docker-compose.yml up
+```
+
+Open you browser and visit `http://localhost:8080/dashboard`

--- a/docker/README.md
+++ b/docker/README.md
@@ -24,7 +24,7 @@ docker run \
   -e GREPTIMEDB_HTTP_HOST=127.0.0.1 \
   -e GREPTIMEDB_HTTP_PORT=4000 \
   -e NGINX_PORT=8080 \
-  --network host
+  --network host \
   greptimedb-dashboard:latest
 ```
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  dashboard:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - GREPTIMEDB_HTTP_HOST=db
+  db:
+    image: "greptime/greptimedb:latest"
+    command: "standalone start --http-addr=0.0.0.0:4000"


### PR DESCRIPTION
This patch adds sample configuration of docker-compose to setup both dashboard and greptimedb.

Also it seems we changed context root from `/` to `/dashboard`, this patch fixes this issue in Dockerfile 