### PR TITLE
fix(compose): failed to start container

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,7 @@ This image uses official node image as build image and offical nginx as base
 image. To build your own docker image, run `docker build` from root of the repo:
 
 ```
-docker build -f docker/Dockerfile -t greptimedb-dashboard .
+docker build -f docker/Dockerfile -t greptime/greptimedb-dashboard .
 ```
 
 ## Run
@@ -25,7 +25,7 @@ docker run \
   -e GREPTIMEDB_HTTP_PORT=4000 \
   -e NGINX_PORT=8080 \
   --network host \
-  greptimedb-dashboard:latest
+  greptime/greptimedb-dashboard:latest
 ```
 
 Open you browser and visit `http://localhost:8080/dashboard`
@@ -53,3 +53,13 @@ docker compose -f docker/docker-compose.yml up
 ```
 
 Open you browser and visit `http://localhost:8080/dashboard`
+
+## Clean
+
+Run `docker compose down` from root of the repo:
+
+```
+docker compose -f docker/docker-compose.yml down
+```
+
+Remove the stopped containers

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile
+    image:
+      greptime/greptimedb-dashboard:latest
     ports:
       - "8080:8080"
     environment:


### PR DESCRIPTION
## What's included

- specify image:tag in compose file, so `docker compose build` will use this image instead of a random one
- use the same image tag in README.md and docker/README.md

which means, if you have the specified image pulled, there is no need to build it