### PR TITLE
fix(docker): always pull latest images before compose up

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -3,10 +3,12 @@ services:
   dashboard:
     platform: linux/amd64
     image: 'greptime/greptimedb-dashboard:latest'
+    pull_policy: always
     ports:
       - '8080:8080'
     environment:
       - GREPTIMEDB_HTTP_HOST=db
   db:
     image: 'greptime/greptimedb:latest'
+    pull_policy: always
     command: 'standalone start --http-addr=0.0.0.0:4000'


### PR DESCRIPTION
https://docs.docker.com/compose/compose-file/#pull_policy
'docker compose up's default 'pull' is 'missing', which will only pull if the image is missing from cache.
We should configure 'pull-policy' to be 'always', which will check to see if the image is the latest, if not, pull the image.