### PR TITLE
feat: add copy to clipboard button for status info

### DIFF
--- a/src/components/text-copyable.vue
+++ b/src/components/text-copyable.vue
@@ -1,0 +1,39 @@
+<template lang="pug">
+a-typography-text(copyable type="secondary" :copy-text="data")
+  span(v-if="showData") {{ data }}
+  template(#copy-icon="{ copied }")
+    .icon-18
+      svg.icon(v-if="copied === false")
+        use(href="#copy")
+      svg.icon(v-else)
+        icon-check.success-color
+  template(#copy-tooltip="{ copied }")
+    | {{ copied ? copiedTooltip : copyTooltip }}
+</template>
+
+<script lang="ts" setup name="TextCopyable">
+  defineProps({
+    data: {
+      type: String,
+      default: '',
+    },
+    showData: {
+      type: Boolean,
+      default: true,
+    },
+    copyTooltip: {
+      type: String,
+      default: 'Copy',
+    },
+    copiedTooltip: {
+      type: String,
+      default: 'Copied',
+    },
+  })
+</script>
+
+<style lang="less" scoped>
+  .arco-typography {
+    display: flex;
+  }
+</style>

--- a/src/locale/en-US.ts
+++ b/src/locale/en-US.ts
@@ -23,6 +23,8 @@ export default {
   'playground.create': 'OK',
   'playground.refeshTitle': 'Warning',
   'playground.refeshNote': 'The Playground has been reclaimed due to timeout. Click OK to re-create the playground',
+  'status.confirm': 'OK',
+  'status.info': 'GreptimeDB Status data has been copied to clipboard',
   ...localeDashboard,
   ...localSetting,
 }

--- a/src/views/dashboard/status/index.vue
+++ b/src/views/dashboard/status/index.vue
@@ -8,20 +8,21 @@ a-modal.guide-modal(
   @ok="handleOk"
 )
   template(#title)
-     div {{ $t('status.info') }}
-     svg.guide-banner
+    div {{ $t('status.info') }}
+    svg.guide-banner
       use(href="#banner")
 
 a-layout.layout
   a-layout-content
-
-    a-card(title='GreptimeDB Status')
+    a-card(v-if="statusInfoRef && statusInfoRef.length > 0" title="GreptimeDB Status")
       template(#extra)
         a-button(type="text" @click="refreshStatus") refresh
         a-button(type="text" @click="copyToClipboard") copy to clipboard
-      a-descriptions(:column='2' bordered)
-        a-descriptions-item(v-for='item of statusInfoRef', :label='item[0]')
+      a-descriptions(bordered :column="2")
+        a-descriptions-item(v-for="item of statusInfoRef" :label="item[0]")
           a-tag {{ item[1] }}
+    a-empty(v-else)
+      template(#extra)
 </template>
 
 <script lang="ts" setup name="Status">
@@ -37,7 +38,7 @@ a-layout.layout
 
   const copyToClipboard = async () => {
     const status = await getStatus()
-    navigator.clipboard.writeText(JSON.stringify(status));
+    navigator.clipboard.writeText(JSON.stringify(status))
     statusModal.value = true
   }
 

--- a/src/views/dashboard/status/index.vue
+++ b/src/views/dashboard/status/index.vue
@@ -17,7 +17,8 @@ a-layout.layout
     a-card(v-if="statusInfoRef && statusInfoRef.length > 0" title="GreptimeDB Status")
       template(#extra)
         a-button(type="text" @click="refreshStatus") refresh
-        a-button(type="text" @click="copyToClipboard") copy to clipboard
+        a-typography
+          a-typography-paragraph(copyable @copy="copyToClipboard")
       a-descriptions(bordered :column="2")
         a-descriptions-item(v-for="item of statusInfoRef" :label="item[0]")
           a-tag {{ item[1] }}

--- a/src/views/dashboard/status/index.vue
+++ b/src/views/dashboard/status/index.vue
@@ -1,37 +1,58 @@
 <template lang="pug">
+a-modal.guide-modal(
+  v-model:visible="statusModal"
+  :mask-closable="false"
+  :ok-text="$t('status.confirm')"
+  :hide-cancel="true"
+  :closable="false"
+  @ok="handleOk"
+)
+  template(#title)
+     div {{ $t('status.info') }}
+     svg.guide-banner
+      use(href="#banner")
+
 a-layout.layout
   a-layout-content
-    a-card(title="GreptimeDB Status")
+
+    a-card(title='GreptimeDB Status')
       template(#extra)
         a-button(type="text" @click="refreshStatus") refresh
-      a-empty(v-if="!statusInfoRef")
-        template(#image)
-          svg.icon-32
-            use(href="#empty")
-        | Status is not supported until GreptimeDB v0.3.1
-      a-descriptions(v-else bordered :column="2")
-        a-descriptions-item(v-for="item of statusInfoRef" :label="item[0]")
+        a-button(type="text" @click="copyToClipboard") copy to clipboard
+      a-descriptions(:column='2' bordered)
+        a-descriptions-item(v-for='item of statusInfoRef', :label='item[0]')
           a-tag {{ item[1] }}
 </template>
 
 <script lang="ts" setup name="Status">
   import { getStatus } from '@/api/status'
 
+  const statusModal = ref()
   const statusInfoRef = ref()
 
   const refreshStatus = async () => {
     const status = await getStatus()
     statusInfoRef.value = Object.entries(status)
   }
+
+  const copyToClipboard = async () => {
+    const status = await getStatus()
+    navigator.clipboard.writeText(JSON.stringify(status));
+    statusModal.value = true
+  }
+
+  const handleOk = () => {
+    statusModal.value = false
+  }
+
   onMounted(async () => {
     refreshStatus()
   })
 </script>
 
 <style lang="stylus" rel="stylesheet/stylus" scoped>
-  .arco-layout-content {
-    background-color: #fff;
-    border-radius: 10px;
-    padding: 10px 20px;
-  }
+  .arco-layout-content
+    background-color #fff
+    border-radius 10px
+    padding 10px 20px
 </style>

--- a/src/views/dashboard/status/index.vue
+++ b/src/views/dashboard/status/index.vue
@@ -1,46 +1,30 @@
 <template lang="pug">
-a-modal.guide-modal(
-  v-model:visible="statusModal"
-  :mask-closable="false"
-  :ok-text="$t('status.confirm')"
-  :hide-cancel="true"
-  :closable="false"
-  @ok="handleOk"
-)
-  template(#title)
-    div {{ $t('status.info') }}
-    svg.guide-banner
-      use(href="#banner")
-
-a-layout.layout
+a-layout.layout.status
   a-layout-content
     a-card(v-if="statusInfoRef && statusInfoRef.length > 0" title="GreptimeDB Status")
       template(#extra)
         a-button(type="text" @click="refreshStatus") refresh
-        a-typography
-          a-typography-paragraph(copyable @copy="copyToClipboard")
+        TextCopyable(copyTooltip="Copy to Clipboard" :data="JSON.stringify(statusData)" :showData="false")
       a-descriptions(bordered :column="2")
         a-descriptions-item(v-for="item of statusInfoRef" :label="item[0]")
           a-tag {{ item[1] }}
     a-empty(v-else)
-      template(#extra)
+      template(#image)
+        svg.icon-32
+          use(href="#empty")
+      | Status is not supported until GreptimeDB v0.3.1
 </template>
 
 <script lang="ts" setup name="Status">
   import { getStatus } from '@/api/status'
 
   const statusModal = ref()
+  const statusData = ref()
   const statusInfoRef = ref()
 
   const refreshStatus = async () => {
-    const status = await getStatus()
-    statusInfoRef.value = Object.entries(status)
-  }
-
-  const copyToClipboard = async () => {
-    const status = await getStatus()
-    navigator.clipboard.writeText(JSON.stringify(status))
-    statusModal.value = true
+    statusData.value = await getStatus()
+    statusInfoRef.value = Object.entries(statusData.value)
   }
 
   const handleOk = () => {
@@ -52,9 +36,24 @@ a-layout.layout
   })
 </script>
 
-<style lang="stylus" rel="stylesheet/stylus" scoped>
-  .arco-layout-content
-    background-color #fff
-    border-radius 10px
-    padding 10px 20px
+<style lang="less" scoped>
+  .arco-layout-content {
+    background-color: #fff;
+    border-radius: 10px;
+    padding: 10px 20px;
+  }
+
+  :deep(.arco-tag) {
+    border-radius: 6px;
+  }
+
+  .status {
+    .arco-typography {
+      line-height: 32px;
+
+      &.copy {
+        margin-bottom: 0;
+      }
+    }
+  }
 </style>


### PR DESCRIPTION
After implementing the status endpoint I thought that it might be handy to have a "copy to clipboard" status information. It can simplify the sharing process of that info between the team and customers.
Attaching the screenshots with my proposal
<img width="1701" alt="image001" src="https://github.com/GreptimeTeam/dashboard/assets/3762201/d9281fed-ec42-47a8-a2d9-dd3739173bf2">
<img width="1690" alt="image002" src="https://github.com/GreptimeTeam/dashboard/assets/3762201/073470cb-0719-478d-8008-4a631867e1d8">

## Refer to a related PR or issue link
https://github.com/GreptimeTeam/greptimedb/issues/1650
https://github.com/GreptimeTeam/greptimedb/pull/1789
https://github.com/GreptimeTeam/dashboard/pull/283

@alili @killme2008 @waynexia 
please let me know what you think? 