### PR TITLE
fix: recognize big number in chart

### DIFF
--- a/.eslintrc-auto-import.json
+++ b/.eslintrc-auto-import.json
@@ -101,6 +101,7 @@
     "PropType": true,
     "Ref": true,
     "VNode": true,
-    "toValue": true
+    "toValue": true,
+    "useWorkbenchStore": true
   }
 }

--- a/src/api/interceptor.ts
+++ b/src/api/interceptor.ts
@@ -52,9 +52,9 @@ axios.interceptors.request.use(
 axios.interceptors.response.use(
   (response: AxiosResponse) => {
     const isV1 = !!response.config.url?.startsWith(`/v1`)
-
     if (isV1) {
-      response.data = JSONbigint.parse(response.data)
+      response.data = JSONbigint({ storeAsString: true }).parse(response.data)
+
       const { data } = response
       if (data.code && data.code !== 0) {
         // v1 and error

--- a/src/assets/style/editor.less
+++ b/src/assets/style/editor.less
@@ -1,5 +1,4 @@
 .editor-card {
-  padding: 16px;
   .ͼo {
     background: var(--main-font-color);
     font-size: 14px;
@@ -57,4 +56,8 @@
 
 .script-form {
   padding-bottom: 8px;
+}
+
+.padding-16 {
+  padding: 16px;
 }

--- a/src/hooks/data-chart.ts
+++ b/src/hooks/data-chart.ts
@@ -16,9 +16,7 @@ export default function useDataChart(data: ResultType) {
     if (!schemaInRecords || !hasTimestamp) return []
     return schemaInRecords.column_schemas
       .filter((item: SchemaType) => numberTypes.find((type: string) => type === item.data_type))
-      .map((item: SchemaType) => ({
-        value: item.name,
-      }))
+      .map((item: SchemaType) => item.name)
   })
 
   const groupByOptions = computed(() => {

--- a/src/views/dashboard/modules/data-view/components/data-chart.vue
+++ b/src/views/dashboard/modules/data-view/components/data-chart.vue
@@ -24,7 +24,7 @@ a-card(v-if="hasChart" :bordered="false")
             :allow-search="false"
             :trigger-props="triggerProps"
           )
-            a-option(v-for="item of yOptions" :key="item.value" :value="item.value") {{ item.value }}
+            a-option(v-for="item of yOptions" :value="item" :label="item") {{ item }}
         a-form-item.select-y(:label="$t('dashboard.groupBy')")
           a-select(
             v-model="chartForm.groupBySelectedTypes"
@@ -217,14 +217,14 @@ a-card(v-if="hasChart" :bordered="false")
   // TODO: Might need to change this
   onMounted(() => {
     if (hasChart.value) {
-      chartForm.selectedYTypes = [yOptions.value[0].value]
+      chartForm.selectedYTypes = [yOptions.value[0]]
       Object.entries(props.defaultChartForm).forEach(([key, value]) => {
         ;(chartForm as any)[key] = (chartForm as any)[key] || value
       })
       chartForm.chartType = props.defaultChartForm.chartType || 'line'
       chartForm.selectedYTypes = props.defaultChartForm.selectedYTypes?.length
         ? props.defaultChartForm.selectedYTypes
-        : [yOptions.value[0].value]
+        : [yOptions.value[0]]
       chartForm.groupBySelectedTypes = [
         ...props.defaultChartForm.groupBySelectedTypes,
         ...chartForm.groupBySelectedTypes,

--- a/src/views/dashboard/modules/data-view/components/data-grid.vue
+++ b/src/views/dashboard/modules/data-view/components/data-grid.vue
@@ -34,7 +34,7 @@ a-card(:bordered="false")
 </template>
 
 <script lang="ts" setup>
-  import { dateTypes } from '@/views/dashboard/config'
+  import { dateTypes, numberTypes } from '@/views/dashboard/config'
   import type { ResultType, SchemaType } from '@/store/modules/code-run/types'
   import dayjs from 'dayjs'
 
@@ -96,6 +96,11 @@ a-card(:bordered="false")
       const tempRow: any = {}
       row.forEach((item: any, index: number) => {
         const columnName = columnNameToDataIndex(props.data.records.schema.column_schemas[index].name)
+        const type = props.data.records.schema.column_schemas[index].data_type
+        // If item is a big number (as string), convert it to Number for table to show
+        if (numberTypes.includes(type) && typeof item === 'string') {
+          item = Number(item)
+        }
         tempRow[columnName] = item
       })
       return tempRow

--- a/src/views/dashboard/playground/code-editor.vue
+++ b/src/views/dashboard/playground/code-editor.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.code-editor
+.code-editor.editor-card
   .code
     .operations(v-if="!disabled")
       a-button(:disabled="runDisabled" :loading="isLoading" @click="runSqlCommand") {{ $t('playground.run') }}

--- a/src/views/dashboard/query/editor.vue
+++ b/src/views/dashboard/query/editor.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-a-card.editor-card(:bordered="false")
+a-card.editor-card.padding-16(:bordered="false")
   a-space.space-between.pb-16
     a-space(size="medium")
       a-button(type="primary" :disabled="isButtonDisabled" @click="runQueryAll()")

--- a/src/views/dashboard/scripts/index.vue
+++ b/src/views/dashboard/scripts/index.vue
@@ -3,7 +3,7 @@ a-layout.layout
   a-layout-sider(:resize-directions="['right']" :width="321")
     ListTabs(:has="['Tables', 'Scripts']")
   a-layout-content
-    a-space.content-space(direction="vertical" fill :size="14")
+    a-space.content-space(direction="vertical" fill size="large")
       PyEditor
       DataView(v-if="!!results?.length" :results="results" :types="types")
       Logs(:logs="queryLogs" :types="types")

--- a/src/views/dashboard/scripts/py-editor.vue
+++ b/src/views/dashboard/scripts/py-editor.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-a-card.editor-card(:bordered="false")
+a-card.editor-card.padding-16(:bordered="false")
   a-space.form-space(size="medium")
     a-form(layout="inline" :model="scriptForm")
       a-form-item(:label="$t('dashboard.scriptName')")


### PR DESCRIPTION
ECharts does not recognize bigNumber or bigInt. Instead of converting big number to bigInt, we store the original number as strings.
But we also need to format certain number strings in `Table`.
Dividing result in PromQL cannot be rendered #320