### PR TITLE
feat: sql shortcuts in tables

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,7 @@
     "echarts",
     "Greptime",
     "hoverable",
+    "Keymap",
     "pinia",
     "promql",
     "sider",

--- a/src/assets/style/global.less
+++ b/src/assets/style/global.less
@@ -153,6 +153,7 @@ body {
     }
 
     .arco-btn-text[type='button'] {
+      justify-content: start;
       width: 100%;
       color: var(--small-font-color);
       font-size: 13px;

--- a/src/assets/style/global.less
+++ b/src/assets/style/global.less
@@ -151,6 +151,16 @@ body {
       color: var(--small-font-color);
       background-color: var(--light-brand-color);
     }
+
+    .arco-btn-text[type='button'] {
+      width: 100%;
+      color: var(--small-font-color);
+      font-size: 13px;
+    }
+
+    .arco-btn-text[type='button']:hover {
+      background-color: var(--grey-bg-color);
+    }
   }
 }
 

--- a/src/assets/style/tableList.less
+++ b/src/assets/style/tableList.less
@@ -81,7 +81,7 @@
   }
 
   .arco-tree-node {
-    padding: 0 8px;
+    padding: 0 2px 0 8px;
     line-height: 36px;
     border-radius: 6px;
   }

--- a/src/assets/style/tableList.less
+++ b/src/assets/style/tableList.less
@@ -77,7 +77,6 @@
     padding: 0 8px;
     line-height: 36px;
     border-radius: 6px;
-    cursor: auto;
   }
 
   .arco-tree-node:hover {

--- a/src/assets/style/tableList.less
+++ b/src/assets/style/tableList.less
@@ -30,6 +30,13 @@
     align-items: center;
     justify-content: space-between;
 
+    .arco-btn-size-medium.arco-btn-only-icon.menu-button {
+      width: 24px;
+      height: 24px;
+      margin-left: 2px;
+      border-radius: 4px;
+    }
+
     .right {
       display: flex;
       width: 15px;

--- a/src/components/short-cut/index.vue
+++ b/src/components/short-cut/index.vue
@@ -1,53 +1,75 @@
 <template lang="pug">
-a-tooltip(:content="code")
-  a-button(type="text" @click="inputFromNewLineToQueryCode(code)") {{ label }}
+a-tooltip(:content="codeInfo.code")
+  a-button(type="text" @click="inputFromNewLineToQueryCode(codeInfo.code, codeInfo.cursorPosition)") {{ label }}
 </template>
 
 <script lang="ts" setup name="ShortCut">
-  import type { TreeChild, TreeData } from '@/store/modules/database/types'
-  import { format } from 'sql-formatter'
+  import type { TableTreeParent, TreeChild } from '@/store/modules/database/types'
 
   const props = defineProps<{
     label: string
     type: string
     node: TreeChild
-    parent: TreeData
+    parent: TableTreeParent
   }>()
 
   const { inputFromNewLineToQueryCode } = useQueryCode()
 
   const formatter = (code: string) => {
-    return format(code, { language: 'mysql', keywordCase: 'upper' })
+    // No format for now.
+    return code
   }
 
-  const getShortcut = (type: string, node: TreeChild, parent?: TreeData) => {
-    if (!parent) {
-      parent = node
-    }
-
+  const getCodeAndCursorPos = (type: string, node: TreeChild, parent: TableTreeParent) => {
     switch (type) {
       case 'select*100':
-        return formatter(`SELECT * FROM ${parent.title} ORDER BY ${parent.timeIndexName} LIMIT 100;`)
+        return {
+          code: formatter(`SELECT * FROM ${parent.title} ORDER BY ${parent.timeIndexName} LIMIT 100;`),
+          cursorPosition: 0,
+        }
       case 'count':
-        return formatter(`SELECT count(*) FROM ${parent.title} GROUP BY ${node.title};`)
+        return {
+          code: formatter(`SELECT count(*) FROM ${parent.title} GROUP BY ${node.title};`),
+          cursorPosition: 0,
+        }
       case 'where=':
-        return formatter(`SELECT * FROM ${parent.title} WHERE ${node.title} = ? ORDER BY ${parent.timeIndexName} DESC;`)
+        return {
+          code: formatter(
+            `SELECT * FROM ${parent.title} WHERE ${node.title} =  ORDER BY ${parent.timeIndexName} DESC;`
+          ),
+          cursorPosition: 16 + parent.timeIndexName.length,
+        }
       case 'select100':
-        return formatter(`SELECT ${node.title} FROM ${parent.title} ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`)
+        return {
+          code: formatter(`SELECT ${node.title} FROM ${parent.title} ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`),
+          cursorPosition: 0,
+        }
       case 'max':
-        return formatter(`SELECT max(${node.title}) FROM ${parent.title};`)
+        return {
+          code: formatter(`SELECT max(${node.title}) FROM ${parent.title};`),
+          cursorPosition: 0,
+        }
       case 'min':
-        return formatter(`SELECT min(${node.title}) FROM ${parent.title};`)
+        return {
+          code: formatter(`SELECT min(${node.title}) FROM ${parent.title};`),
+          cursorPosition: 0,
+        }
       case 'where<':
-        return formatter(
-          `SELECT * FROM ${parent.title} WHERE ${parent.timeIndexName} < ? ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`
-        )
+        return {
+          code: formatter(
+            `SELECT * FROM ${parent.title} WHERE ${parent.timeIndexName} <  ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`
+          ),
+          cursorPosition: 26 + parent.timeIndexName.length,
+        }
       default:
-        return ''
+        return {
+          code: '',
+          cursorPosition: 0,
+        }
     }
   }
 
-  const code = computed(() => {
-    return getShortcut(props.type, props.node, props.parent)
+  const codeInfo = computed(() => {
+    return getCodeAndCursorPos(props.type, props.node, props.parent)
   })
 </script>

--- a/src/components/short-cut/index.vue
+++ b/src/components/short-cut/index.vue
@@ -1,0 +1,53 @@
+<template lang="pug">
+a-tooltip(:content="code")
+  a-button(type="text" @click="inputFromNewLineToQueryCode(code)") {{ label }}
+</template>
+
+<script lang="ts" setup name="ShortCut">
+  import type { TreeChild, TreeData } from '@/store/modules/database/types'
+  import { format } from 'sql-formatter'
+
+  const props = defineProps<{
+    label: string
+    type: string
+    node: TreeChild
+    parent: TreeData
+  }>()
+
+  const { inputFromNewLineToQueryCode } = useQueryCode()
+
+  const formatter = (code: string) => {
+    return format(code, { language: 'mysql', keywordCase: 'upper' })
+  }
+
+  const getShortcut = (type: string, node: TreeChild, parent?: TreeData) => {
+    if (!parent) {
+      parent = node
+    }
+
+    switch (type) {
+      case 'select*100':
+        return formatter(`SELECT * FROM ${parent.title} ORDER BY ${parent.timeIndexName} LIMIT 100;`)
+      case 'count':
+        return formatter(`SELECT count(*) FROM ${parent.title} GROUP BY ${node.title};`)
+      case 'where=':
+        return formatter(`SELECT * FROM ${parent.title} WHERE ${node.title} = ? ORDER BY ${parent.timeIndexName} DESC;`)
+      case 'select100':
+        return formatter(`SELECT ${node.title} FROM ${parent.title} ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`)
+      case 'max':
+        return formatter(`SELECT max(${node.title}) FROM ${parent.title};`)
+      case 'min':
+        return formatter(`SELECT min(${node.title}) FROM ${parent.title};`)
+      case 'where<':
+        return formatter(
+          `SELECT * FROM ${parent.title} WHERE ${parent.timeIndexName} < ? ORDER BY ${parent.timeIndexName} DESC LIMIT 100;`
+        )
+      default:
+        return ''
+    }
+  }
+
+  const code = computed(() => {
+    return getShortcut(props.type, props.node, props.parent)
+  })
+</script>

--- a/src/hooks/query-code.ts
+++ b/src/hooks/query-code.ts
@@ -59,6 +59,8 @@ export default function useQueryCode() {
       changes = {
         from: state.doc.length,
         insert: `${code}`,
+        // TODO: Scroll not working,
+        scrollIntoView: true,
       }
       cursorPosition = state.doc.length + code.length - cursorBack
     } else {
@@ -66,9 +68,11 @@ export default function useQueryCode() {
       changes = {
         from: state.doc.length,
         insert: `\n${code}`,
+        scrollIntoView: true,
       }
       cursorPosition = state.doc.length + code.length + 1 - cursorBack
     }
+    view.value.focus()
     view.value.dispatch({
       changes,
       selection: EditorSelection.create([EditorSelection.cursor(cursorPosition)]),

--- a/src/hooks/query-code.ts
+++ b/src/hooks/query-code.ts
@@ -40,11 +40,19 @@ export default function useQueryCode() {
   const { codeType } = storeToRefs(useAppStore())
   const { results } = storeToRefs(useCodeRunStore())
 
-  const insertNameToQueryCode = (name: any) => {
+  const insertNameToQueryCode = (name: string) => {
     codes.value[queryType.value] =
       codes.value[queryType.value].substring(0, cursorAt.value[0]) +
       name +
       codes.value[queryType.value].substring(cursorAt.value[1])
+  }
+
+  const inputFromNewLineToQueryCode = (code: string) => {
+    if (codes.value[queryType.value].trim() !== '') {
+      codes.value[queryType.value] += `\n${code}`
+    } else {
+      codes.value[queryType.value] += code
+    }
   }
 
   const selectCodeType = () => {
@@ -99,6 +107,7 @@ export default function useQueryCode() {
     selectCodeType,
     getResultsByType,
     runQuery,
+    inputFromNewLineToQueryCode,
     queryCode,
     cursorAt,
     queryOptions,

--- a/src/hooks/sider-tabs.ts
+++ b/src/hooks/sider-tabs.ts
@@ -1,5 +1,5 @@
 import { useDataBaseStore } from '@/store'
-import { TreeChild, TreeData } from '@/store/modules/database/types'
+import { ScriptTreeData, TreeChild, TreeData } from '@/store/modules/database/types'
 
 const tablesSearchKey = ref('')
 const scriptsSearchKey = ref('')
@@ -28,9 +28,9 @@ export default function useSiderTabs() {
   }
 
   const searchList = (keyword: string) => {
-    const loop = (data: TreeData[]) => {
-      const result: TreeData[] = []
-      data.forEach((item: TreeData) => {
+    const loop = (data: ScriptTreeData[]) => {
+      const result: ScriptTreeData[] = []
+      data.forEach((item: ScriptTreeData) => {
         if (item.title.toLowerCase().indexOf(keyword.toLowerCase()) > -1) {
           result.push({ ...item })
         }

--- a/src/store/modules/database/index.ts
+++ b/src/store/modules/database/index.ts
@@ -4,12 +4,12 @@ import { TreeChild, TreeData } from './types'
 const useDataBaseStore = defineStore('database', () => {
   const { database } = storeToRefs(useAppStore())
   const tablesData = ref()
-
   const scriptsData = ref()
+  const originTablesTree = ref<TreeData[]>([])
   const tablesLoading = ref(false)
   const scriptsLoading = ref(false)
 
-  const originTablesTree = computed(() => {
+  const getOriginTablesTree = () => {
     const tempArray: TreeData[] = []
     let key = 0
     if (tablesData.value) {
@@ -23,9 +23,8 @@ const useDataBaseStore = defineStore('database', () => {
         key += 1
       })
     }
-
     return tempArray
-  })
+  }
 
   const addChildren = (key: number, children: TreeChild[]) => {
     originTablesTree.value[key].children = children
@@ -54,8 +53,10 @@ const useDataBaseStore = defineStore('database', () => {
     try {
       const res = await editorAPI.getTables()
       tablesData.value = res
+      originTablesTree.value = getOriginTablesTree()
     } catch (error) {
       tablesData.value = null
+      originTablesTree.value = []
       tablesLoading.value = false
       return false
     }

--- a/src/store/modules/database/index.ts
+++ b/src/store/modules/database/index.ts
@@ -26,8 +26,9 @@ const useDataBaseStore = defineStore('database', () => {
     return tempArray
   }
 
-  const addChildren = (key: number, children: TreeChild[]) => {
+  const addChildren = (key: number, children: TreeChild[], timeIndexName: string) => {
     originTablesTree.value[key].children = children
+    originTablesTree.value[key].timeIndexName = timeIndexName
   }
 
   const originScriptsList = computed(() => {

--- a/src/store/modules/database/index.ts
+++ b/src/store/modules/database/index.ts
@@ -1,23 +1,25 @@
 import editorAPI from '@/api/editor'
-import { TreeChild, TreeData } from './types'
+import { ScriptTreeData, TableTreeChild, TableTreeParent } from './types'
 
 const useDataBaseStore = defineStore('database', () => {
   const { database } = storeToRefs(useAppStore())
   const tablesData = ref()
   const scriptsData = ref()
-  const originTablesTree = ref<TreeData[]>([])
+  const originTablesTree = ref<TableTreeParent[]>([])
   const tablesLoading = ref(false)
   const scriptsLoading = ref(false)
 
   const getOriginTablesTree = () => {
-    const tempArray: TreeData[] = []
+    const tempArray: TableTreeParent[] = []
     let key = 0
     if (tablesData.value) {
       tablesData.value.output[0].records.rows.forEach((item: Array<string>) => {
-        const node: TreeData = {
+        const node: TableTreeParent = {
           title: item.join(),
           key,
           children: [],
+          timeIndexName: '',
+          code: '',
         }
         tempArray.push(node)
         key += 1
@@ -26,16 +28,16 @@ const useDataBaseStore = defineStore('database', () => {
     return tempArray
   }
 
-  const addChildren = (key: number, children: TreeChild[], timeIndexName: string) => {
+  const addChildren = (key: number, children: TableTreeChild[], timeIndexName: string) => {
     originTablesTree.value[key].children = children
     originTablesTree.value[key].timeIndexName = timeIndexName
   }
 
   const originScriptsList = computed(() => {
-    const tempArray: TreeData[] = []
+    const tempArray: ScriptTreeData[] = []
     if (scriptsData.value) {
       scriptsData.value.output[0].records.rows.forEach((item: Array<string>) => {
-        const node: TreeData = {
+        const node: ScriptTreeData = {
           title: item[1],
           key: item[1],
           code: item[2],

--- a/src/store/modules/database/types.ts
+++ b/src/store/modules/database/types.ts
@@ -8,18 +8,25 @@ export interface TreeChild {
   key: string | number
   title: string
   isLeaf?: boolean
-  dataType?: string
-  iconType?: string
-  parentKey?: number
 }
 
-export interface TreeData {
-  key: string | number
-  title: string
+export interface TreeData extends TreeChild {
   children?: TreeChild[]
-  isLeaf?: boolean
-  dataType?: string
-  iconType?: string
-  code?: string
-  timeIndexName?: string
+}
+
+export interface TableTreeChild extends TreeChild {
+  key: string
+  dataType: string
+  iconType: string
+  parentKey: number
+}
+
+export interface TableTreeParent extends TreeData {
+  key: number
+  code: string
+  timeIndexName: string
+}
+
+export interface ScriptTreeData extends TreeData {
+  code: string
 }

--- a/src/store/modules/database/types.ts
+++ b/src/store/modules/database/types.ts
@@ -10,6 +10,7 @@ export interface TreeChild {
   isLeaf?: boolean
   dataType?: string
   iconType?: string
+  parentKey?: number
 }
 
 export interface TreeData {
@@ -20,4 +21,5 @@ export interface TreeData {
   dataType?: string
   iconType?: string
   code?: string
+  timeIndexName?: string
 }

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -45,7 +45,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
                   ShortCut(
                     :type="item.value"
                     :node="nodeData"
-                    :parent="originTablesTree[nodeData.parentKey]"
+                    :parent="nodeData.iconType ? originTablesTree[nodeData.parentKey] : nodeData"
                     :label="item.label"
                   )
               a-doption
@@ -63,7 +63,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
   import useQueryCode from '@/hooks/query-code'
   import usePythonCode from '@/hooks/python-code'
   import useSiderTabs from '@/hooks/sider-tabs'
-  import type { TreeChild, TreeData } from '@/store/modules/database/types'
+  import type { TableTreeChild, TableTreeParent } from '@/store/modules/database/types'
   import type { OptionsType } from '@/types/global'
   import { useClipboard } from '@vueuse/core'
 
@@ -85,7 +85,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     if (treeRef.value) treeRef.value.expandAll(false)
   }
 
-  const loadMore = (nodeData: TreeData) => {
+  const loadMore = (nodeData: TableTreeParent) => {
     return new Promise<void>((resolve, reject) => {
       getTableByName(nodeData.title)
         .then((result: any) => {
@@ -93,7 +93,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
           const {
             records: { rows },
           } = output[0]
-          const treeChildren: TreeChild[] = []
+          const treeChildren: TableTreeChild[] = []
           let timeIndexName = '%TIME_INDEX%'
           rows.forEach((row: string[]) => {
             // row[0]: "Field" (field name),
@@ -110,10 +110,10 @@ a-spin(style="width: 100%" :loading="tablesLoading")
               isLeaf: true,
               dataType: row[1],
               iconType: row[4],
-              parentKey: nodeData.key as number,
+              parentKey: nodeData.key,
             })
           })
-          addChildren(nodeData.key as number, treeChildren, timeIndexName)
+          addChildren(nodeData.key, treeChildren, timeIndexName)
           resolve()
         })
         .catch(() => {
@@ -164,8 +164,8 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     ],
   }
 
-  const clickMenu = (event: Event, nodeData: TreeData) => {
-    if (nodeData.children && expandedKeys.value?.includes(nodeData.key as number)) {
+  const clickMenu = (event: Event, nodeData: TableTreeParent) => {
+    if (nodeData.children && expandedKeys.value?.includes(nodeData.key)) {
       event.stopPropagation()
     }
   }

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -49,7 +49,8 @@ a-spin(style="width: 100%" :loading="tablesLoading")
                     :label="item.label"
                   )
               a-doption
-                a-button(type="text" @click="copy(nodeData.title)") Copy To Clipboard
+                a-tooltip(content="Copy to Clipboard")
+                  a-button(type="text" @click="copy(nodeData.title)") Copy name
     template(#switcher-icon)
       IconDown
   .tree-scrollbar(v-else)

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -36,9 +36,9 @@ a-spin(style="width: 100%" :loading="tablesLoading")
             transition(name="slide-fade")
               .data-type {{ nodeData.dataType }}
           a-dropdown(trigger="click" position="right" @click="(event) => clickMenu(event, nodeData)")
-            a-button(type="text")
+            a-button.menu-button(type="text")
               template(#icon)
-                icon-more
+                icon-more.icon-18
             template(#content)
               a-doption(v-for="item of SHORTCUT_MAP[nodeData.iconType || 'TABLE']")
                 a-spin(:loading="nodeData.children && !nodeData.children.length")
@@ -49,12 +49,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
                     :label="item.label"
                   )
               a-doption
-                TextCopyable.no-hover-bg(
-                  :data="nodeData.title"
-                  :show-data="false"
-                  :copy-tooltip="$t('dashboard.insertName')"
-                  @copy="insertName(nodeData.title)"
-                )
+                a-button(type="text" @click="copy(nodeData.title)") Copy To Clipboard
     template(#switcher-icon)
       IconDown
   .tree-scrollbar(v-else)
@@ -69,7 +64,10 @@ a-spin(style="width: 100%" :loading="tablesLoading")
   import useSiderTabs from '@/hooks/sider-tabs'
   import type { TreeChild, TreeData } from '@/store/modules/database/types'
   import type { OptionsType } from '@/types/global'
+  import { useClipboard } from '@vueuse/core'
 
+  const source = ref('')
+  const { text, copy, copied, isSupported } = useClipboard({ source })
   const route = useRoute()
   const { insertNameToQueryCode } = useQueryCode()
   const { insertNameToPyCode } = usePythonCode()

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -138,27 +138,27 @@ a-spin(style="width: 100%" :loading="tablesLoading")
   }
 
   const SHORTCUT_MAP: { [key: string]: OptionsType[] } = {
-    'TABLE': [{ value: 'select*100', label: 'SELECT * 100' }],
+    'TABLE': [{ value: 'select*100', label: 'Query table' }],
     'FIELD': [
-      { value: 'select100', label: 'SELECT 100' },
+      { value: 'select100', label: 'Query column' },
       {
         value: 'max',
-        label: 'MAX',
+        label: 'Query max',
       },
       {
         value: 'min',
-        label: 'MIN',
+        label: 'Query min',
       },
     ],
     'PRIMARY KEY': [
-      { value: 'count', label: 'COUNT' },
-      { value: 'where=', label: 'WHERE =' },
+      { value: 'count', label: 'Count by' },
+      { value: 'where=', label: 'Filter by' },
     ],
     'TIME INDEX': [
-      { value: 'select*100', label: 'SELECT * 100' },
+      { value: 'select*100', label: 'Query table' },
       {
         value: 'where<',
-        label: 'WHERE <',
+        label: 'Filter by',
       },
     ],
   }

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -35,13 +35,13 @@ a-spin(style="width: 100%" :loading="tablesLoading")
           .div(v-if="nodeData.iconType")
             transition(name="slide-fade")
               .data-type {{ nodeData.dataType }}
-          a-dropdown(trigger="click" position="right" @click="(event) => clickMenu(event, nodeData)")
+          a-dropdown.menu-dropdown(trigger="click" position="right" @click="(event) => clickMenu(event, nodeData)")
             a-button.menu-button(type="text")
               template(#icon)
                 icon-more.icon-18
             template(#content)
               a-doption(v-for="item of SHORTCUT_MAP[nodeData.iconType || 'TABLE']")
-                a-spin(:loading="nodeData.children && !nodeData.children.length")
+                a-spin(style="width: 100%" :loading="nodeData.children && !nodeData.children.length")
                   ShortCut(
                     :type="item.value"
                     :node="nodeData"

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -11,7 +11,9 @@ a-spin(style="width: 100%" :loading="tablesLoading")
   a-tree.table-tree(
     v-if="tablesTreeData && tablesTreeData.length > 0"
     ref="treeRef"
+    v-model:expanded-keys="expandedKeys"
     size="small"
+    action-on-node-click="expand"
     :block-node="true"
     :data="tablesTreeData"
     :load-more="loadMore"
@@ -19,27 +21,42 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     :virtual-list-props="{ height: 'calc(100vh - 220px)' }"
   )
     template(#icon="node")
-      svg.icon-16(v-if="node.node.iconType")
-        use(:href="ICON_MAP[node.node.iconType]")
+      a-tooltip(:content="node.node.iconType")
+        svg.icon-16(v-if="node.node.iconType")
+          use(:href="ICON_MAP[node.node.iconType]")
     template(#title="nodeData")
       .tree-data
-        .data-title(v-if="nodeData.iconType")
-          | {{ nodeData.title }}
-        .div(v-if="nodeData.iconType")
-          transition(name="slide-fade")
-            .data-type {{ nodeData.dataType }}
         a-tooltip.data-type(v-if="!nodeData.iconType" mini :content="nodeData.title")
           .data-title
             | {{ nodeData.title }}
+        .data-title(v-else)
+          | {{ nodeData.title }}
+        .tree-data
+          .div(v-if="nodeData.iconType")
+            transition(name="slide-fade")
+              .data-type {{ nodeData.dataType }}
+          a-dropdown(trigger="click" position="right" @click="(event) => clickMenu(event, nodeData)")
+            a-button(type="text")
+              template(#icon)
+                icon-more
+            template(#content)
+              a-doption(v-for="item of SHORTCUT_MAP[nodeData.iconType || 'TABLE']")
+                a-spin(:loading="nodeData.children && !nodeData.children.length")
+                  ShortCut(
+                    :type="item.value"
+                    :node="nodeData"
+                    :parent="originTablesTree[nodeData.parentKey]"
+                    :label="item.label"
+                  )
+              a-doption
+                TextCopyable.no-hover-bg(
+                  :data="nodeData.title"
+                  :show-data="false"
+                  :copy-tooltip="$t('dashboard.insertName')"
+                  @copy="insertName(nodeData.title)"
+                )
     template(#switcher-icon)
       IconDown
-    template(#extra="nodeData")
-      TextCopyable.no-hover-bg(
-        :data="nodeData.title"
-        :show-data="false"
-        :copy-tooltip="$t('dashboard.insertName')"
-        @copy="insertName(nodeData.title)"
-      )
   .tree-scrollbar(v-else)
     EmptyStatus
 </template>
@@ -51,15 +68,17 @@ a-spin(style="width: 100%" :loading="tablesLoading")
   import usePythonCode from '@/hooks/python-code'
   import useSiderTabs from '@/hooks/sider-tabs'
   import type { TreeChild, TreeData } from '@/store/modules/database/types'
+  import type { OptionsType } from '@/types/global'
 
   const route = useRoute()
   const { insertNameToQueryCode } = useQueryCode()
   const { insertNameToPyCode } = usePythonCode()
   const { tablesSearchKey, tablesTreeData } = useSiderTabs()
-  const { tablesLoading } = storeToRefs(useDataBaseStore())
+  const { tablesLoading, originTablesTree } = storeToRefs(useDataBaseStore())
   const { getTableByName, getTables, addChildren } = useDataBaseStore()
 
   const treeRef = ref()
+  const expandedKeys = ref<number[]>()
 
   const refreshTables = () => {
     tablesSearchKey.value = ''
@@ -67,7 +86,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     if (treeRef.value) treeRef.value.expandAll(false)
   }
 
-  const loadMore = (nodeData: any) => {
+  const loadMore = (nodeData: TreeData) => {
     return new Promise<void>((resolve, reject) => {
       getTableByName(nodeData.title)
         .then((result: any) => {
@@ -76,17 +95,26 @@ a-spin(style="width: 100%" :loading="tablesLoading")
             records: { rows },
           } = output[0]
           const treeChildren: TreeChild[] = []
-          rows.forEach((row: any) => {
-            // TODO: make code more readable
+          let timeIndexName = '%TIME_INDEX%'
+          rows.forEach((row: string[]) => {
+            // row[0]: "Field" (field name),
+            // row[1]: "Type" (data type),
+            // row[2]: "Null",
+            // row[3]: "Default",
+            // row[4]: "Semantic Type",
+            if (row[4] === 'TIME INDEX') {
+              timeIndexName = row[0]
+            }
             treeChildren.push({
               title: row[0],
               key: `${nodeData.title}.${row[0]}`,
               isLeaf: true,
               dataType: row[1],
               iconType: row[4],
+              parentKey: nodeData.key as number,
             })
           })
-          addChildren(nodeData.key, treeChildren)
+          addChildren(nodeData.key as number, treeChildren, timeIndexName)
           resolve()
         })
         .catch(() => {
@@ -109,6 +137,38 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     'FIELD': '#value',
     'PRIMARY KEY': '#primary-key',
     'TIME INDEX': '#time-index',
+  }
+
+  const SHORTCUT_MAP: { [key: string]: OptionsType[] } = {
+    'TABLE': [{ value: 'select*100', label: 'SELECT * 100' }],
+    'FIELD': [
+      { value: 'select100', label: 'SELECT 100' },
+      {
+        value: 'max',
+        label: 'MAX',
+      },
+      {
+        value: 'min',
+        label: 'MIN',
+      },
+    ],
+    'PRIMARY KEY': [
+      { value: 'count', label: 'COUNT' },
+      { value: 'where=', label: 'WHERE =' },
+    ],
+    'TIME INDEX': [
+      { value: 'select*100', label: 'SELECT * 100' },
+      {
+        value: 'where<',
+        label: 'WHERE <',
+      },
+    ],
+  }
+
+  const clickMenu = (event: Event, nodeData: TreeData) => {
+    if (nodeData.children && expandedKeys.value?.includes(nodeData.key as number)) {
+      event.stopPropagation()
+    }
   }
 </script>
 

--- a/src/views/dashboard/modules/table-list.vue
+++ b/src/views/dashboard/modules/table-list.vue
@@ -40,7 +40,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
               template(#icon)
                 icon-more.icon-18
             template(#content)
-              a-doption(v-for="item of SHORTCUT_MAP[nodeData.iconType || 'TABLE']")
+              a-doption(v-for="item of SHORTCUT_MAP[nodeData.iconType || 'TABLE']" v-show="route.name === 'query'")
                 a-spin(style="width: 100%" :loading="nodeData.children && !nodeData.children.length")
                   ShortCut(
                     :type="item.value"
@@ -127,6 +127,7 @@ a-spin(style="width: 100%" :loading="tablesLoading")
     scripts: insertNameToPyCode,
   }
 
+  // Deprecated
   const insertName = (name: string) => {
     const routeName = route.name as string
     return INSERT_MAP[routeName](name)

--- a/src/views/dashboard/query/editor.vue
+++ b/src/views/dashboard/query/editor.vue
@@ -105,13 +105,13 @@ a-card.editor-card.padding-16(:bordered="false")
     isButtonDisabled,
     primaryCodeRunning,
     secondaryCodeRunning,
+    view,
     selectCodeType,
   } = useQueryCode()
 
   const lineStart = ref()
   const lineEnd = ref()
   const selectedCode = ref()
-  const view = shallowRef()
   const triggerVisible = ref(false)
   const rangePickerVisible = ref(false)
 


### PR DESCRIPTION
- [x] Edit data structure for tables tree. Children need `parent` name. Parents need `time index` name.
- [x] Table name needs to load-more if we click the entire tree node.
- [x] The cursor should move to where we want users to input.
- [x] The cursor should move even if the editor is not focused in.
- [ ] Scroll to the bottom?.
- [x] New copy to clipboard
- [x] Style