### PR TITLE
feat(editor): support SQL keyword hint for tables and columns names

### DIFF
--- a/src/views/dashboard/query/editor.vue
+++ b/src/views/dashboard/query/editor.vue
@@ -194,15 +194,13 @@ a-card.editor-card.padding-16(:bordered="false")
     return { schema }
   })
 
-  const extensions: any = ref({
+  const extensions = {
     sql: [sql(sqlConfig.value), oneDark, keymap.of(defaultKeymap as any)],
     promQL: [promQL.asExtension(), oneDark],
-  })
+  }
 
   watch(sqlConfig, () => {
-    extensions.value = {
-      sql: [sql(sqlConfig.value), oneDark, keymap.of(defaultKeymap as any)],
-    }
+    extensions.sql = [sql(sqlConfig.value), oneDark, keymap.of(defaultKeymap as any)]
   })
 
   const openTimeSelect = () => {


### PR DESCRIPTION
We use SQLConfig from lang-sql of Codemirror [here.](https://github.com/codemirror/lang-sql#user-content-sqlconfig)
In the future, we hope to add more easy-to-use hints and autocompletion.
For #248 