### PR TITLE
feat(router): auto detect context path

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,7 +10,7 @@ NProgress.configure({ showSpinner: false }) // NProgress Configuration
 
 const extractContextPath = (path: string): string => {
     // Find the index of 'dashboard'
-    const dashboardIndex = path.indexOf('/dashboard');
+    const dashboardIndex = path.lastIndexOf('/dashboard');
 
     if (dashboardIndex === -1) {
         return ''; // Return empty string if 'dashboard' is not found

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -8,8 +8,22 @@ import createRouteGuard from './guard'
 
 NProgress.configure({ showSpinner: false }) // NProgress Configuration
 
+const extractContextPath = (path: string): string => {
+    // Find the index of 'dashboard'
+    const dashboardIndex = path.indexOf('/dashboard');
+
+    if (dashboardIndex === -1) {
+        return ''; // Return empty string if 'dashboard' is not found
+    }
+
+    // Extract the substring up to 'dashboard'
+    const contextPath = path.substring(0, dashboardIndex + 1);
+
+    return contextPath;
+};
+
 const router = createRouter({
-  history: createWebHistory(),
+  history: createWebHistory(extractContextPath(window.location.pathname)),
   routes: [
     {
       path: '/',


### PR DESCRIPTION
This patch add a function to detect base path automatically with the assumption that this application is always deployed under a `/dashboard` path.

tested under

- `/abc/dashboard`
- `/dashboard`