### PR TITLE
fix: resolve settings drawer not showing

### DIFF
--- a/src/components/global-setting/index.vue
+++ b/src/components/global-setting/index.vue
@@ -169,7 +169,7 @@ a-drawer.settings-drawer(
 <style lang="less">
   .settings-drawer {
     .arco-drawer {
-      height: min-content;
+      height: auto;
       margin-left: 18px;
       border-radius: 4px;
       box-shadow: 0 4px 10px 0 var(--border-color);


### PR DESCRIPTION
Resolves the issue that the settings drawer is not showing up in Safari.

fixes #429