### PR TITLE
feat(editor): promql format; store selected query type

### DIFF
--- a/src/api/formatter.ts
+++ b/src/api/formatter.ts
@@ -1,0 +1,25 @@
+import axios from 'axios'
+
+export interface PromqlFormatRequest {
+  query: string
+}
+
+export interface PromqlFormatResponse {
+  status: string
+  data: string
+}
+
+/**
+ * Format PromQL query using the Prometheus API
+ * @param query - The PromQL query string to format
+ * @returns Promise<PromqlFormatResponse> - The formatted query response
+ */
+
+const prometheusBaseURL = 'v1/prometheus/api/v1'
+export const formatPromqlQuery = async (query: string): Promise<PromqlFormatResponse> => {
+  return axios.post(`${prometheusBaseURL}/format_query`, `query=${encodeURIComponent(query)}`, {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+  })
+}

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -1,4 +1,6 @@
 import { format as sqlFormat } from 'sql-formatter'
+import { formatPromqlQuery, type PromqlFormatResponse } from '@/api/formatter'
+import { Message } from '@arco-design/web-vue'
 
 export const parseSqlStatements = (sql: string): { text: string; start: number; end: number }[] => {
   if (!sql) return []
@@ -127,12 +129,32 @@ export const sqlFormatter = (code: string) => {
       formatted = formatted.endsWith(';') ? formatted : `${formatted};`
     } catch (formattingError) {
       console.warn(`Failed to format SQL statement: ${formattingError}`)
+      Message.warning('Failed to format. Please check console for details.')
       formatted = trimmed.endsWith(';') ? trimmed : `${trimmed};`
+      return formatted
     }
 
     return formatted
   } catch (error) {
     console.error('SQL formatting error:', error)
+    return code
+  }
+}
+
+export const promqlFormatter = async (code: string): Promise<string> => {
+  try {
+    const trimmed = code.trim()
+    if (!trimmed) {
+      return code
+    }
+    const response = await formatPromqlQuery(trimmed)
+    if (response.status === 'success') {
+      return response.data
+    }
+    console.warn('Unexpected response format from PromQL formatter:', response)
+    return trimmed
+  } catch (error) {
+    console.error('PromQL formatting error:', error)
     return code
   }
 }

--- a/src/utils/sql.ts
+++ b/src/utils/sql.ts
@@ -131,9 +131,7 @@ export const sqlFormatter = (code: string) => {
       console.warn(`Failed to format SQL statement: ${formattingError}`)
       Message.warning('Failed to format. Please check console for details.')
       formatted = trimmed.endsWith(';') ? trimmed : `${trimmed};`
-      return formatted
     }
-
     return formatted
   } catch (error) {
     console.error('SQL formatting error:', error)


### PR DESCRIPTION
1. Use `format_query` to format promql.
2. Store selected query type in local storage.