### PR TITLE
feat: metric ui

### DIFF
--- a/src/components/time-range-select/index.vue
+++ b/src/components/time-range-select/index.vue
@@ -31,6 +31,7 @@ TimeSelect(
       emptyStr: 'Any time',
       buttonSize: 'small',
       showAnyTime: true, // Default to showing "Any time" option
+      flexDirection: 'row-reverse',
     }
   )
 

--- a/src/components/time-select/index.vue
+++ b/src/components/time-select/index.vue
@@ -107,8 +107,10 @@ a-trigger#time-select(
 
   const selectTimeLength = (value: any) => {
     emit('update:timeLength', value)
-    emit('update:timeRange', [])
-    emit('change')
+    if (props.timeRange.length > 0) {
+      emit('update:timeRange', [])
+    }
+
     visible.value = false
     rangePickerVisible.value = false
   }

--- a/src/hooks/use-series.ts
+++ b/src/hooks/use-series.ts
@@ -42,6 +42,9 @@ export function useSeries() {
   const queryStep = ref<number>()
   const currentStep = ref(0)
 
+  // Instant query specific time (for table data)
+  const instantQueryTime = ref<Date | null>(null)
+
   // Time range and step management
   const timeRangeState = useTimeRange({ time: 10 })
   const { rangeTime, time, unixTimeRange } = timeRangeState
@@ -51,10 +54,14 @@ export function useSeries() {
   const previousStep = ref<number>()
 
   // Execute PromQL instant query (for table data - current values)
-  const executeInstantQuery = async (query: string) => {
+  const executeInstantQuery = async (query: string, timestamp?: Date) => {
     currentQuery.value = query
 
-    const response = await executePromQL(query, currentTimeRange.value[1].toString())
+    // Use provided timestamp, or instantQueryTime, or current time as fallback
+    const queryTime = timestamp || instantQueryTime.value || new Date()
+    const unixTimestamp = Math.floor(queryTime.getTime() / 1000).toString()
+
+    const response = await executePromQL(query, unixTimestamp)
 
     instantQueryResult.value = response.data.result
     return response.data
@@ -138,6 +145,7 @@ export function useSeries() {
     rangeQueryResult,
     instantQueryResult, // For table data
     queryLoading,
+    instantQueryTime, // For instant query timestamp
 
     // Time range state
     rangeTime,

--- a/src/hooks/use-series.ts
+++ b/src/hooks/use-series.ts
@@ -43,7 +43,7 @@ export function useSeries() {
   const currentStep = ref(0)
 
   // Instant query specific time (for table data)
-  const instantQueryTime = ref<Date | null>(null)
+  const instantQueryTime = ref<string | null>(null)
 
   // Time range and step management
   const timeRangeState = useTimeRange({ time: 10 })
@@ -59,7 +59,7 @@ export function useSeries() {
 
     // Use provided timestamp, or instantQueryTime, or current time as fallback
     const queryTime = timestamp || instantQueryTime.value || new Date()
-    const unixTimestamp = Math.floor(queryTime.getTime() / 1000).toString()
+    const unixTimestamp = Math.floor(new Date(queryTime).getTime() / 1000).toString()
 
     const response = await executePromQL(query, unixTimestamp)
 

--- a/src/views/dashboard/metrics/components/metric-sidebar.vue
+++ b/src/views/dashboard/metrics/components/metric-sidebar.vue
@@ -53,10 +53,7 @@ a-card.metrics-sidebar(:bordered="false")
           template(#icon)
             icon-plus
 
-    // Metrics Explorer Modal
     MetricsExplorer(v-model:visible="showMetricsExplorer" @select="selectMetricFromExplorer")
-
-    // Single MetricMenu instance - controlled from outside
     MetricMenu(
       v-if="metricMenuVisible"
       v-model:popup-visible="metricMenuVisible"
@@ -101,29 +98,21 @@ a-card.metrics-sidebar(:bordered="false")
     (e: 'insertText', text: string): void
   }>()
 
-  // App store for database
   const appStore = useAppStore()
 
-  // Local state for metrics
   const metrics = ref<Array<{ name: string }>>([])
   const loading = ref(false)
   const currentSearchQuery = ref('')
 
-  // Sidebar state
   const selectedMetric = useLocalStorage<string | null>('metrics-explorer-last-selected', null)
 
-  // Local state for labels
   const labels = ref<any[]>([])
 
-  // Metrics explorer state
   const showMetricsExplorer = ref(false)
 
-  // Single MetricMenu state
   const metricMenuVisible = ref(false)
   const selectedNodeData = ref<any>(null)
   const contextMenuPosition = ref({ x: 0, y: 0 })
-
-  // Computed properties
   const metricOptions = computed(() => {
     return metrics.value.map((metric) => ({
       label: metric.name,
@@ -131,7 +120,6 @@ a-card.metrics-sidebar(:bordered="false")
     }))
   })
 
-  // Common method to fetch metrics
   const getMetrics = async () => {
     try {
       loading.value = true
@@ -139,7 +127,6 @@ a-card.metrics-sidebar(:bordered="false")
       if (response.data) {
         const metricList = response.data.map((name: string) => ({ name }))
         metrics.value = metricList
-        // Clear search query when fetching all metrics
         currentSearchQuery.value = ''
       }
     } catch (err: any) {
@@ -148,9 +135,6 @@ a-card.metrics-sidebar(:bordered="false")
       loading.value = false
     }
   }
-
-  // Methods
-  // Fetch labels for a specific metric and store locally
   const fetchLabelsForMetric = async (metricName: string) => {
     try {
       const response = await getLabelNames(metricName)
@@ -167,7 +151,6 @@ a-card.metrics-sidebar(:bordered="false")
     }
   }
 
-  // Debounced search function using VueUse
   const debouncedSearch = useDebounceFn(async (query: string) => {
     if (query.trim()) {
       try {
@@ -183,13 +166,10 @@ a-card.metrics-sidebar(:bordered="false")
     } else {
       metrics.value = []
     }
-  }, 300) // 300ms delay
+  }, 300)
 
   const onMetricSearch = async (query: string) => {
-    // Store the current search query
     currentSearchQuery.value = query
-
-    // Execute the debounced search
     await debouncedSearch(query)
   }
 
@@ -203,7 +183,6 @@ a-card.metrics-sidebar(:bordered="false")
 
   const refreshData = async () => {
     if (currentSearchQuery.value.trim()) {
-      // If there's a current search, refresh with the search query
       try {
         loading.value = true
         const safe = currentSearchQuery.value.trim()
@@ -214,13 +193,11 @@ a-card.metrics-sidebar(:bordered="false")
           metrics.value = metricList
         }
       } catch (err: any) {
-        // Fallback to fetching all metrics
         await getMetrics()
       } finally {
         loading.value = false
       }
     } else {
-      // If no search query, refresh all metrics
       await getMetrics()
     }
   }
@@ -290,7 +267,6 @@ a-card.metrics-sidebar(:bordered="false")
     await getMetrics()
   })
 
-  // Watch for database changes to refresh metrics
   watch(
     () => appStore.database,
     () => {
@@ -366,7 +342,6 @@ a-card.metrics-sidebar(:bordered="false")
     overflow-x: auto;
     padding: 0 15px;
   }
-  // Tree node styling to match query sidebar
   :deep(.metrics-tree) {
     .data-title {
       color: var(--main-font-color);

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -167,13 +167,14 @@ a-card.metrics-chart(:bordered="false")
 
   const graphHeight = 530
   const legendHeight = computed(() => {
-    return Math.min(seriesData.value.length * 20, 300)
+    return Math.min(seriesData.value.length * 20, 240)
   })
+  const legendGap = 30
   // Dynamic chart height based on series count
   const chartHeight = computed(() => {
     const baseHeight = graphHeight
     const dynamicHeight = legendHeight.value
-    return baseHeight + dynamicHeight
+    return baseHeight + dynamicHeight + legendGap
   })
 
   const chartOption = computed<EChartsOption>(() => {
@@ -275,13 +276,12 @@ a-card.metrics-chart(:bordered="false")
         bottom: 0,
         type: 'scroll',
         orient: 'vertical',
-        top: chartHeight.value - legendHeight.value + 10,
-        itemHeight: 20,
+        top: graphHeight + 20,
       },
       grid: {
         left: 30,
         right: 30,
-        bottom: legendHeight.value, // Dynamic bottom margin based on series count
+        bottom: legendHeight.value + legendGap, // Dynamic bottom margin based on series count
         top: 30,
         containLabel: true,
       },

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -42,16 +42,17 @@ a-card.metrics-chart(:bordered="false")
 </template>
 
 <script setup lang="ts">
-  import { ref, computed, watch, nextTick, inject } from 'vue'
+  import { ref, computed, watch, nextTick, inject, type Ref, type ComputedRef } from 'vue'
   import Chart from '@/components/raw-chart/index.vue'
   import TimeRangeSelect from '@/components/time-range-select/index.vue'
 
   import dayjs from 'dayjs'
   import type { EChartsOption } from 'echarts'
   import StepSelector from './step-selector.vue'
+  import type { MetricsContext } from '../types'
 
   // Inject the metrics context
-  const metricsContext = inject('metricsContext') as any
+  const metricsContext = inject<MetricsContext>('metricsContext')
 
   // Destructure the context for easier access
   const {
@@ -66,7 +67,6 @@ a-card.metrics-chart(:bordered="false")
     unixTimeRange,
     stepSelectionType,
     currentStep,
-    handleChartQuery,
     handleTimeRangeUpdate,
   } = metricsContext
 

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -43,6 +43,7 @@ a-card.metrics-chart(:bordered="false")
 
 <script setup lang="ts">
   import { ref, computed, watch, nextTick, inject, type Ref, type ComputedRef } from 'vue'
+  import { useWindowSize } from '@vueuse/core'
   import Chart from '@/components/raw-chart/index.vue'
   import TimeRangeSelect from '@/components/time-range-select/index.vue'
 
@@ -74,6 +75,9 @@ a-card.metrics-chart(:bordered="false")
   // Chart state
   const chartRef = ref()
   const localChartType = chartType
+
+  // Get window size for responsive legend height
+  const { height: windowHeight } = useWindowSize()
 
   // Watch for time range changes only - step changes are handled separately
   // to avoid multiple executions when time change causes step change
@@ -177,10 +181,14 @@ a-card.metrics-chart(:bordered="false")
   })
 
   const graphHeight = 530
-  const legendHeight = computed(() => {
-    return Math.min(seriesData.value.length * 20, 240)
-  })
   const legendGap = 30
+  const legendItemHeight = 18
+  const legendHeight = computed(() => {
+    const seriesCount = seriesData.value.length
+    const maxAvailableHeight = windowHeight.value - graphHeight - legendGap - 200 // 200px for other UI elements
+    const calculatedHeight = seriesCount * (legendItemHeight + 5)
+    return Math.min(calculatedHeight, Math.max(maxAvailableHeight, 100)) // Minimum 100px
+  })
   // Dynamic chart height based on series count
   const chartHeight = computed(() => {
     const baseHeight = graphHeight
@@ -288,6 +296,8 @@ a-card.metrics-chart(:bordered="false")
         type: 'scroll',
         orient: 'vertical',
         top: graphHeight + 20,
+        itemHeight: legendItemHeight,
+        itemGap: 5,
       },
       grid: {
         left: 30,

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -155,7 +155,7 @@ a-card.metrics-chart(:bordered="false")
   const seriesData = computed(() => {
     if (!hasData.value) return []
 
-    let filteredData = rangeQueryResult.value.filter((series) => series.values && series.values.length > 0)
+    let filteredData = rangeQueryResult.value.slice()
 
     // Fill missing timestamps if time range and step are available
     if (timeRange.value && timeRange.value.length === 2 && step.value) {

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -16,9 +16,6 @@ a-card.metrics-chart(:bordered="false")
             :unix-time-range="unixTimeRange"
           )
 
-      span.series-count(v-if="seriesData.length > 0") 
-        | ({{ seriesData.length }} {{ seriesData.length === 1 ? 'series' : 'series' }}, step: {{ step }}s)
-
     a-space(style="margin-left: auto")
       a-radio-group(v-model="localChartType" type="button" size="small")
         a-radio(value="line") Lines
@@ -35,6 +32,8 @@ a-card.metrics-chart(:bordered="false")
         :options="chartOption"
         @datazoom="handleDataZoom"
       )
+      .series-count(v-if="seriesData.length > 0") 
+        | ({{ seriesData.length }} {{ seriesData.length === 1 ? 'series' : 'series' }}, step: {{ step }}s)
 
   .empty-state(v-else)
     a-empty(description="No data to display")
@@ -48,7 +47,7 @@ a-card.metrics-chart(:bordered="false")
   import { ref, computed, watch, nextTick, inject } from 'vue'
   import Chart from '@/components/raw-chart/index.vue'
   import TimeRangeSelect from '@/components/time-range-select/index.vue'
-  import { IconLoading, IconPlayArrow } from '@arco-design/web-vue/es/icon'
+
   import dayjs from 'dayjs'
   import type { EChartsOption } from 'echarts'
   import StepSelector from './step-selector.vue'
@@ -400,11 +399,6 @@ a-card.metrics-chart(:bordered="false")
       }
     }
 
-    // Hide toolbox but keep functionality
-    :deep(.echarts-tooltip) {
-      // Keep tooltip visible
-    }
-
     :deep(.echarts-toolbox) {
       // Hide toolbox completely but keep zoom functionality
       display: none !important;
@@ -431,5 +425,9 @@ a-card.metrics-chart(:bordered="false")
       height: 0 !important;
       overflow: hidden !important;
     }
+  }
+  .series-count {
+    text-align: center;
+    color: var(--color-text-secondary);
   }
 </style>

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -68,11 +68,22 @@ a-card.metrics-chart(:bordered="false")
     stepSelectionType,
     currentStep,
     handleTimeRangeUpdate,
+    updateQueryParams,
   } = metricsContext
 
   // Chart state
   const chartRef = ref()
   const localChartType = chartType
+
+  // Watch for time range changes only - step changes are handled separately
+  // to avoid multiple executions when time change causes step change
+  watch(
+    () => JSON.stringify({ time: time.value, rangeTime: rangeTime.value, step: currentStep.value }),
+    () => {
+      // Update URL parameters when time range changes
+      updateQueryParams()
+    }
+  )
 
   // Helper functions for chart type handling
   const getChartType = (type: string): string => {

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -32,8 +32,6 @@ a-card.metrics-chart(:bordered="false")
         :options="chartOption"
         @datazoom="handleDataZoom"
       )
-      .series-count(v-if="seriesData.length > 0") 
-        | ({{ seriesData.length }} {{ seriesData.length === 1 ? 'series' : 'series' }}, step: {{ step }}s)
 
   .empty-state(v-else)
     a-empty(description="No data to display")

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -186,7 +186,7 @@ a-card.metrics-chart(:bordered="false")
   const legendHeight = computed(() => {
     const seriesCount = seriesData.value.length
     const maxAvailableHeight = windowHeight.value - graphHeight - legendGap - 200 // 200px for other UI elements
-    const calculatedHeight = seriesCount * (legendItemHeight + 5)
+    const calculatedHeight = seriesCount * (legendItemHeight + 10)
     return Math.min(calculatedHeight, Math.max(maxAvailableHeight, 100)) // Minimum 100px
   })
   // Dynamic chart height based on series count
@@ -297,7 +297,7 @@ a-card.metrics-chart(:bordered="false")
         orient: 'vertical',
         top: graphHeight + 20,
         itemHeight: legendItemHeight,
-        itemGap: 5,
+        itemGap: 10,
       },
       grid: {
         left: 30,

--- a/src/views/dashboard/metrics/components/metrics-chart.vue
+++ b/src/views/dashboard/metrics/components/metrics-chart.vue
@@ -28,7 +28,7 @@ a-card.metrics-chart(:bordered="false")
       Chart(
         :key="chartKey"
         ref="chartRef"
-        height="610px"
+        :height="chartHeight + 'px'"
         :options="chartOption"
         @datazoom="handleDataZoom"
       )
@@ -165,6 +165,17 @@ a-card.metrics-chart(:bordered="false")
     return filteredData
   })
 
+  const graphHeight = 530
+  const legendHeight = computed(() => {
+    return Math.min(seriesData.value.length * 20, 300)
+  })
+  // Dynamic chart height based on series count
+  const chartHeight = computed(() => {
+    const baseHeight = graphHeight
+    const dynamicHeight = legendHeight.value
+    return baseHeight + dynamicHeight
+  })
+
   const chartOption = computed<EChartsOption>(() => {
     if (!hasData.value) return {}
     const series = seriesData.value.map((item, index) => {
@@ -186,7 +197,6 @@ a-card.metrics-chart(:bordered="false")
         }
         return [timestamp * 1000, parseFloat(value as string)]
       })
-      // Don't filter out null values - let ECharts handle them with connectNulls: false
 
       // Determine if we should show symbols based on data point count
       const shouldShowSymbols = localChartType.value === 'scatter' || data.length <= 20
@@ -228,8 +238,6 @@ a-card.metrics-chart(:bordered="false")
       }
     })
 
-    const gridBottom = Math.min(series.length * 40 + 20, 160)
-
     return {
       tooltip: {
         trigger: 'axis',
@@ -267,12 +275,13 @@ a-card.metrics-chart(:bordered="false")
         bottom: 0,
         type: 'scroll',
         orient: 'vertical',
-        top: 610 - gridBottom + 20,
+        top: chartHeight.value - legendHeight.value + 10,
+        itemHeight: 20,
       },
       grid: {
         left: 30,
         right: 30,
-        bottom: gridBottom, // Dynamic bottom margin based on series count
+        bottom: legendHeight.value, // Dynamic bottom margin based on series count
         top: 30,
         containLabel: true,
       },
@@ -381,9 +390,6 @@ a-card.metrics-chart(:bordered="false")
 
 <style lang="less" scoped>
   .metrics-chart {
-    .tab-controls {
-    }
-
     .empty-state {
       text-align: center;
       padding: 60px 20px;

--- a/src/views/dashboard/metrics/components/prom-ql-editor.vue
+++ b/src/views/dashboard/metrics/components/prom-ql-editor.vue
@@ -54,10 +54,7 @@
   const appStore = useAppStore()
   let editorView: any = null
 
-  // Use the same Prometheus API base URL as in metrics.ts
   const prometheusBaseURL = '/v1/prometheus/api/v1'
-
-  // Helper function to create a Response-like object with proper body stream
   const createResponse = (data: any, status = 200, statusText = 'OK'): Response => {
     const responseBody = JSON.stringify(data)
     const bodyStream = new ReadableStream({
@@ -74,7 +71,7 @@
       headers: new Headers(),
       redirected: false,
       type: 'cors' as const,
-      url: '', // This URL is not used by the extension, it uses the one from the original request
+      url: '',
       body: bodyStream,
       bodyUsed: false,
       clone: () => ({ ...data, body: bodyStream }),
@@ -87,11 +84,9 @@
     } as unknown as Response
   }
 
-  // Handle query execution
   const handleQuery = () => {
     emit('query')
   }
-  // Helper function to normalize URL paths
   const normalizeUrl = (resource: any): string => {
     const requestUrl = typeof resource === 'object' && resource.url ? resource.url : resource
 
@@ -113,11 +108,9 @@
     return requestUrl
   }
 
-  // Custom HTTP client for GreptimeDB API
   const myHTTPClient = async (resource: any, options: any = {}): Promise<Response> => {
     const requestUrl = normalizeUrl(resource)
 
-    // Skip metadata requests as GreptimeDB doesn't support this endpoint
     if (requestUrl.includes('/metadata')) {
       return createResponse({ status: 'success', data: {} })
     }
@@ -145,32 +138,25 @@
         ...config,
       })
 
-      // Format response data based on endpoint type
       let responseData = { status: 'success', data: response.data }
 
-      // Handle different endpoint types
       if (
         requestUrl.includes('/label/__name__/values') ||
         requestUrl.includes('/labels') ||
         (requestUrl.includes('/label/') && requestUrl.includes('/values'))
       ) {
-        // For metric names, label names, and label values - wrap array in prometheus format
         responseData = { status: 'success', data: response.data }
 
-        // Ensure data is an array
         if (!Array.isArray(response.data)) {
           responseData.data = []
         }
       } else if (requestUrl.includes('/series')) {
-        // For series requests (used for label suggestions) - return raw series objects
         responseData = { status: 'success', data: response.data }
 
-        // Ensure data is an array
         if (!Array.isArray(response.data)) {
           responseData.data = []
         }
       } else {
-        // Default case - wrap in prometheus format
         responseData = { status: 'success', data: response.data }
 
         if (!Array.isArray(response.data)) {
@@ -200,40 +186,38 @@
         remote: {
           url: '',
           fetchFn: myHTTPClient,
-          lookbackInterval: 60 * 60 * 1000, // 1 hour
+          lookbackInterval: 60 * 60 * 1000,
         },
       })
       .asExtension()
   }
 
-  // Custom keymap to prevent Enter from creating new lines (Prometheus UI style)
   const singleLineKeymap = Prec.highest(
     keymap.of([
       {
         key: 'Enter',
-        run: () => true, // Prevent default behavior - no new lines
+        run: () => true,
       },
       {
         key: 'Shift-Enter',
-        run: () => true, // Prevent Shift+Enter new lines
+        run: () => true,
       },
       {
         key: 'Ctrl-Enter',
         run: () => {
           handleQuery()
-          return true // Prevent default behavior
+          return true
         },
       },
       {
         key: 'Cmd-Enter',
         run: () => {
-          return true // Prevent default behavior (Mac)
+          return true
         },
       },
     ])
   )
 
-  // Extensions array
   const extensions = computed(() => {
     const exts = [basicSetup, singleLineKeymap]
 
@@ -244,19 +228,14 @@
     return exts
   })
 
-  // Handle code changes and filter out newlines
   const codeUpdate = (content: string) => {
-    // Remove all newlines to enforce single-line behavior
     const singleLineContent = content.replace(/[\r\n]+/g, ' ').trim()
     emit('update:modelValue', singleLineContent)
   }
 
-  // Handle editor ready
   const onEditorReady = (payload: any) => {
     editorView = payload.view
   }
-
-  // Public method to insert text at cursor
   const insertTextAtCursor = (text: string) => {
     if (!editorView) return
 
@@ -274,26 +253,22 @@
     editorView.focus()
   }
 
-  // Focus the editor
   const focus = () => {
     if (editorView) {
       editorView.focus()
     }
   }
 
-  // Get current cursor position
   const getCursorPosition = () => {
     if (!editorView) return 0
     return editorView.state.selection.main.head
   }
 
-  // Get current text
   const getText = () => {
     if (!editorView) return ''
     return editorView.state.doc.toString()
   }
 
-  // Watch for database changes and refresh extension
   watch(
     () => appStore.database,
     () => {
@@ -301,12 +276,9 @@
     }
   )
 
-  // Initialize on mount
   onMounted(() => {
     initializePromQLExtension()
   })
-
-  // Expose methods for parent component
   defineExpose({
     insertTextAtCursor,
     focus,
@@ -339,14 +311,12 @@
     outline: none;
   }
 
-  // Smooth transition for focus state
   :deep(.cm-editor) {
     border: 1px solid var(--color-border);
     border-radius: 4px 0 0 4px;
     transition: all 0.2s ease-in-out;
   }
 
-  // Single line editor styles (Prometheus UI style)
   :deep(.cm-editor) {
     height: 40px;
     overflow: visible;
@@ -377,7 +347,6 @@
     background-color: transparent;
   }
 
-  // Hide line numbers like Prometheus UI
   :deep(.cm-gutters) {
     display: none !important;
   }
@@ -386,7 +355,6 @@
     display: none !important;
   }
 
-  // Ensure autocomplete popup is visible
   :deep(.cm-tooltip) {
     z-index: 1000;
   }
@@ -394,8 +362,6 @@
   :deep(.cm-tooltip.cm-completionInfo) {
     z-index: 1001;
   }
-
-  // Prometheus UI style autocomplete popup
   :deep(.cm-tooltip.cm-tooltip-autocomplete) {
     background-color: #f8f8f8;
     border: 1px solid rgba(52, 79, 113, 0.2);
@@ -433,7 +399,6 @@
     min-width: 30%;
   }
 
-  // Prometheus UI style completion info popup
   :deep(.cm-tooltip.cm-completionInfo) {
     background-color: #d6ebff;
     border: 1px solid rgba(52, 79, 113, 0.2);
@@ -447,7 +412,6 @@
     z-index: 1001;
   }
 
-  // Prometheus UI style completion icons
   :deep(.cm-completionIcon) {
     box-sizing: content-box;
     font-size: 16px;
@@ -458,14 +422,11 @@
     opacity: 1;
   }
 
-  // Prometheus UI style matched text highlighting
   :deep(.cm-completionMatchedText) {
     color: #0066bf;
     text-decoration: none;
     font-weight: bold;
   }
-
-  // Prometheus UI style completion details
   :deep(.cm-completionDetail) {
     float: right;
     color: #999;

--- a/src/views/dashboard/metrics/components/prom-ql-editor.vue
+++ b/src/views/dashboard/metrics/components/prom-ql-editor.vue
@@ -25,7 +25,7 @@
         template(#icon)
           icon-loading(v-if="queryLoading" spin)
           icon-play-arrow(v-else)
-        | Execute Query
+        | {{ $t('dashboard.runQuery') }}
 </template>
 
 <script setup lang="ts">

--- a/src/views/dashboard/metrics/components/prom-ql-editor.vue
+++ b/src/views/dashboard/metrics/components/prom-ql-editor.vue
@@ -1,17 +1,31 @@
 <template lang="pug">
-CodeMirror(
-  style="height: 100%"
-  :placeholder="placeholder"
-  :modelValue="props.modelValue"
-  :extensions="extensions"
-  :spellcheck="false"
-  :autofocus="false"
-  :indent-with-tab="false"
-  :tabSize="2"
-  :disabled="disabled"
-  @change="codeUpdate"
-  @ready="onEditorReady"
-)
+.promql-editor-container
+  CodeMirror(
+    style="height: 100%"
+    :placeholder="placeholder"
+    :modelValue="props.modelValue"
+    :extensions="extensions"
+    :spellcheck="false"
+    :autofocus="false"
+    :indent-with-tab="false"
+    :tabSize="2"
+    :disabled="disabled"
+    @change="codeUpdate"
+    @ready="onEditorReady"
+  )
+  .query-button-container
+    a-tooltip(content="Ctrl + Enter" position="right")
+      a-button(
+        type="primary"
+        size="large"
+        style="height: 40px; border-radius: 0 4px 4px 0"
+        :loading="queryLoading"
+        @click="handleQuery"
+      )
+        template(#icon)
+          icon-loading(v-if="queryLoading" spin)
+          icon-play-arrow(v-else)
+        | Execute Query
 </template>
 
 <script setup lang="ts">
@@ -23,11 +37,13 @@ CodeMirror(
   import axios from 'axios'
   import { keymap, EditorView } from '@codemirror/view'
   import { Prec } from '@codemirror/state'
+  import { IconLoading, IconPlayArrow } from '@arco-design/web-vue/es/icon'
 
   const props = defineProps<{
     modelValue: string
     disabled?: boolean
     placeholder?: string
+    queryLoading?: boolean
   }>()
 
   const emit = defineEmits<{
@@ -71,6 +87,10 @@ CodeMirror(
     } as unknown as Response
   }
 
+  // Handle query execution
+  const handleQuery = () => {
+    emit('query')
+  }
   // Helper function to normalize URL paths
   const normalizeUrl = (resource: any): string => {
     const requestUrl = typeof resource === 'object' && resource.url ? resource.url : resource
@@ -200,7 +220,7 @@ CodeMirror(
       {
         key: 'Ctrl-Enter',
         run: () => {
-          emit('query')
+          handleQuery()
           return true // Prevent default behavior
         },
       },
@@ -296,6 +316,19 @@ CodeMirror(
 </script>
 
 <style lang="less" scoped>
+  .promql-editor-container {
+    display: flex;
+    align-items: stretch;
+    gap: 0;
+    min-height: 40px;
+  }
+
+  .query-button-container {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
   :deep(.arco-card.light-editor-card) {
     padding-right: 0;
   }
@@ -309,7 +342,7 @@ CodeMirror(
   // Smooth transition for focus state
   :deep(.cm-editor) {
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: 4px 0 0 4px;
     transition: all 0.2s ease-in-out;
   }
 
@@ -317,6 +350,7 @@ CodeMirror(
   :deep(.cm-editor) {
     height: 40px;
     overflow: visible;
+    width: 100%;
   }
 
   :deep(.cm-scroller) {

--- a/src/views/dashboard/metrics/components/step-selector.vue
+++ b/src/views/dashboard/metrics/components/step-selector.vue
@@ -31,6 +31,7 @@
 
 <script setup lang="ts">
   import { ref, computed, watch, onMounted } from 'vue'
+  import { useDebounceFn } from '@vueuse/core'
   import { IconDown } from '@arco-design/web-vue/es/icon'
 
   // Props
@@ -144,15 +145,18 @@
     emit('update:selectionType', selectedOption.value)
   })
 
-  // Watch for custom step input changes
-  watch(customStepInput, (newInput) => {
+  // Debounced function for custom step input changes
+  const debouncedStepUpdate = useDebounceFn((newInput: string) => {
     if (currentSelection.value === 'custom' && newInput) {
       const parsedValue = parseStepInput(newInput)
       if (parsedValue !== null) {
         emit('update:stepValue', parsedValue)
       }
     }
-  })
+  }, 500) // 500ms debounce
+
+  // Watch for custom step input changes
+  watch(customStepInput, debouncedStepUpdate)
 
   // Helper function to format step for display
   const formatStepDisplay = (step: number): string => {

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -492,4 +492,10 @@ a-layout.new-layout
     align-items: center;
     min-height: 200px;
   }
+  :deep(.arco-tabs-tab-active) {
+    color: var(--brand-color);
+  }
+  :deep(.arco-tabs-nav-ink) {
+    background-color: var(--brand-color);
+  }
 </style>

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -37,7 +37,6 @@ a-layout.new-layout
                 allow-clear
                 style="width: 200px"
                 size="small"
-                @change="handleInstantQueryTimeChange"
               )
 
           .table-section
@@ -64,7 +63,6 @@ a-layout.new-layout
   import { useStorage } from '@vueuse/core'
   import { useSeries } from '@/hooks/use-series'
   import { Message } from '@arco-design/web-vue'
-  import { IconExclamationCircleFill } from '@arco-design/web-vue/es/icon'
   import { storeToRefs } from 'pinia'
   import { useAppStore } from '@/store'
   import MetricSidebar from './components/metric-sidebar.vue'
@@ -209,7 +207,7 @@ a-layout.new-layout
 
     // Instant query time (for table tab)
     if (instantQueryTime.value && activeTab.value === 'table') {
-      query.instantTime = instantQueryTime.value.toISOString()
+      query.instantTime = instantQueryTime.value as unknown as string
     } else {
       delete query.instantTime
     }
@@ -341,15 +339,6 @@ a-layout.new-layout
   const handleInsertText = (text: string) => {
     if (promqlEditorRef.value) {
       promqlEditorRef.value.insertTextAtCursor(text)
-    }
-  }
-
-  // Handle instant query time change
-  const handleInstantQueryTimeChange = (date: Date) => {
-    instantQueryTime.value = date
-    // Auto-trigger query when time changes if there's a query and we're on table tab
-    if (currentQuery.value.trim() && activeTab.value === 'table') {
-      updateQueryParams()
     }
   }
 

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -350,7 +350,9 @@ a-layout.new-layout
   })
 
   watch(activeTab, (newTab) => {
-    updateQueryParams()
+    setTimeout(() => {
+      updateQueryParams()
+    }, 200)
   })
 
   // Watch for route query changes (excluding queryId) to sync back to variables

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -143,7 +143,9 @@ a-layout.new-layout
       const length = parseInt(timeLength as string, 10)
       if (!Number.isNaN(length)) {
         time.value = length
-        rangeTime.value = []
+        if (rangeTime.value.length > 0) {
+          rangeTime.value = []
+        }
       }
     }
 
@@ -174,14 +176,7 @@ a-layout.new-layout
 
     // Instant query time
     if (instantTime && typeof instantTime === 'string') {
-      try {
-        const parsedTime = new Date(instantTime)
-        if (!Number.isNaN(parsedTime.getTime())) {
-          instantQueryTime.value = parsedTime
-        }
-      } catch (e) {
-        // Invalid date, ignore
-      }
+      instantQueryTime.value = instantTime
     }
   }
 
@@ -324,6 +319,7 @@ a-layout.new-layout
     chartType,
     stepSelectionType,
     handleTimeRangeUpdate,
+    updateQueryParams,
   })
 
   const handleCopyText = async (text: string) => {
@@ -354,6 +350,13 @@ a-layout.new-layout
       updateQueryParams()
     }, 200)
   })
+
+  watch(
+    () => instantQueryTime.value,
+    () => {
+      updateQueryParams()
+    }
+  )
 
   // Watch for route query changes (excluding queryId) to sync back to variables
   watch(

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -79,6 +79,7 @@ a-layout.new-layout
   import { Message } from '@arco-design/web-vue'
   import { storeToRefs } from 'pinia'
   import { useAppStore } from '@/store'
+  import type { MetricsContext } from './types'
   import MetricSidebar from './components/metric-sidebar.vue'
   import PromQLEditor from './components/prom-ql-editor.vue'
   import MetricsChart from './components/metrics-chart.vue'
@@ -98,9 +99,6 @@ a-layout.new-layout
     // Time range state
     rangeTime,
     time,
-    unixTimeRange,
-    queryStep,
-    currentTimeRange,
     currentStep,
     queryLoading,
     instantQueryTime,
@@ -307,9 +305,6 @@ a-layout.new-layout
     return tableResults.value?.length || 0
   })
 
-  // Legacy handlers that now just update query params (which triggers execution)
-  const handleChartQuery = updateQueryParams
-  const handleTableQuery = updateQueryParams
   const handleRunQuery = updateQueryParams
 
   // Handle time range update from chart selection
@@ -322,7 +317,7 @@ a-layout.new-layout
   }
 
   // Provide the context to child components
-  provide('metricsContext', {
+  provide<MetricsContext>('metricsContext', {
     // Series hook data and methods
     ...seriesHook,
     // Additional shared state and methods

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -257,7 +257,7 @@ a-layout.new-layout
     if (!tableResults.value || tableResults.value.length === 0) return []
     const rows: any[] = []
     tableResults.value.forEach((series) => {
-      const metricName = series.metric?.__name__ || 'unknown'
+      const metricName = series.metric?.__name__
       const seriesLabels = { ...series.metric }
       delete seriesLabels.__name__
 

--- a/src/views/dashboard/metrics/index.vue
+++ b/src/views/dashboard/metrics/index.vue
@@ -52,7 +52,9 @@ a-layout.new-layout
               :pagination="false"
               :scroll="{ x: 800 }"
               :bordered="false"
+              :show-header="false"
             )
+
           .empty-state(v-else)
             a-empty(description="No data to display")
               template(#image)
@@ -234,14 +236,14 @@ a-layout.new-layout
       title: 'Series',
       dataIndex: 'series',
       key: 'series',
-      width: 300,
+      width: 400,
       ellipsis: true,
     },
     {
-      title: 'Value',
-      dataIndex: 'value',
-      key: 'value',
-      width: 120,
+      title: 'Values',
+      dataIndex: 'values',
+      key: 'values',
+      width: 200,
       align: 'right' as const,
     },
   ])
@@ -259,11 +261,22 @@ a-layout.new-layout
         .join(', ')
       const seriesName = labelStr ? `${metricName}{${labelStr}}` : metricName
 
-      // Instant query returns single value, not array of values
+      // Handle both single value and multiple timestamp-value pairs
       if (series.value !== undefined) {
+        let valuesList
+        // Check if value is a single [timestamp, value] pair or array of pairs
+        if (Array.isArray(series.value) && series.value.length === 2 && !Array.isArray(series.value[0])) {
+          valuesList = series.value[1]
+        } else if (Array.isArray(series.value) && Array.isArray(series.value[0])) {
+          // Multiple timestamp-value pairs: [[timestamp, value], [timestamp, value], ...]
+          valuesList = series.value
+            .map((valuePoint: [number, string]) => `${valuePoint[0]} ${valuePoint[1]}`)
+            .join('\n')
+        }
+
         rows.push({
           series: seriesName,
-          value: series.value[1],
+          values: valuesList,
         })
       }
     })
@@ -454,6 +467,7 @@ a-layout.new-layout
   :deep(.arco-tabs-content) {
     padding-top: 0;
   }
+
   .table-section {
     margin-top: 16px;
   }

--- a/src/views/dashboard/metrics/types.ts
+++ b/src/views/dashboard/metrics/types.ts
@@ -1,0 +1,10 @@
+import type { Ref } from 'vue'
+import type { useSeries } from '@/hooks/use-series'
+
+// Define the metrics context type that combines seriesHook with custom fields
+export interface MetricsContext extends ReturnType<typeof useSeries> {
+  // Custom fields
+  chartType: Ref<string>
+  stepSelectionType: Ref<string>
+  handleTimeRangeUpdate: (newTimeRange: [number, number]) => void
+}

--- a/src/views/dashboard/metrics/types.ts
+++ b/src/views/dashboard/metrics/types.ts
@@ -7,4 +7,5 @@ export interface MetricsContext extends ReturnType<typeof useSeries> {
   chartType: Ref<string>
   stepSelectionType: Ref<string>
   handleTimeRangeUpdate: (newTimeRange: [number, number]) => void
+  updateQueryParams: () => void
 }


### PR DESCRIPTION
## display table and chart in different tabs  to make instant query and range query independent
<img width="1765" height="816" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/ad5afea5-36b0-42dd-8911-d787b0f7e4a5" />
<img width="1762" height="1060" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/89714b0d-b090-4cfa-9e64-cc82049ff775" />

* use tabs ui
* instant time picker
* trigger query by query parameter
* highlight label name
* support multiple values in a  table row 

