### PR TITLE
feat: add perses trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,8 @@
     "@perses-dev/stat-chart-plugin": "0.12.0-beta.0",
     "@perses-dev/table-plugin": "0.11.0-beta.0",
     "@perses-dev/timeseries-chart-plugin": "0.12.0-beta.0",
+    "@perses-dev/trace-table-plugin": "0.10.0-beta.0",
+    "@perses-dev/tracing-gantt-chart-plugin": "0.12.0-beta.0",
     "@prometheus-io/codemirror-promql": "0.305.0",
     "@tanstack/react-query": "^5.66.7",
     "@tauri-apps/api": "^2.*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,12 @@ importers:
       '@perses-dev/timeseries-chart-plugin':
         specifier: 0.12.0-beta.0
         version: 0.12.0-beta.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@hookform/resolvers@4.1.3(react-hook-form@7.71.2(react@18.3.1)))(@perses-dev/components@0.53.0-beta.4(j6z42mbiwccbaprd6rlzvg5cje))(@perses-dev/core@0.53.0-beta.4)(@perses-dev/plugin-system@0.53.0-beta.4(j3zj3rnf3zj4ypnpyryuhhnuym))(date-fns-tz@3.2.0(date-fns@4.1.0))(date-fns@4.1.0)(echarts@5.6.0)(immer@10.2.0)(lodash@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@perses-dev/trace-table-plugin':
+        specifier: 0.10.0-beta.0
+        version: 0.10.0-beta.0(zffdvsqjn7tukdqqnp5cqct2nq)
+      '@perses-dev/tracing-gantt-chart-plugin':
+        specifier: 0.12.0-beta.0
+        version: 0.12.0-beta.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@hookform/resolvers@4.1.3(react-hook-form@7.71.2(react@18.3.1)))(@perses-dev/components@0.53.0-beta.4(j6z42mbiwccbaprd6rlzvg5cje))(@perses-dev/core@0.53.0-beta.4)(@perses-dev/plugin-system@0.53.0-beta.4(j3zj3rnf3zj4ypnpyryuhhnuym))(date-fns-tz@3.2.0(date-fns@4.1.0))(date-fns@4.1.0)(echarts@5.6.0)(lodash@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@prometheus-io/codemirror-promql':
         specifier: 0.305.0
         version: 0.305.0(@codemirror/autocomplete@6.9.0(@codemirror/language@6.9.0)(@codemirror/state@6.4.1)(@codemirror/view@6.18.0)(@lezer/common@1.2.0))(@codemirror/language@6.9.0)(@codemirror/lint@6.4.1)(@codemirror/state@6.4.1)(@codemirror/view@6.18.0)(@lezer/common@1.2.0)(@lezer/highlight@1.2.0)(@lezer/lr@1.3.10)
@@ -1490,6 +1496,22 @@ packages:
       '@types/react':
         optional: true
 
+  '@mui/x-data-grid@7.29.12':
+    resolution: {integrity: sha512-MaEC7ubr/je8jVWjdRU7LxBXAzlOZwFEdNdvlDUJIYkRa3TRCQ1HsY8Gd8Od0jnlnMYn9M4BrEfOrq9VRnt4bw==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      '@emotion/react': ^11.9.0
+      '@emotion/styled': ^11.8.1
+      '@mui/material': ^5.15.14 || ^6.0.0 || ^7.0.0
+      '@mui/system': ^5.15.14 || ^6.0.0 || ^7.0.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@emotion/react':
+        optional: true
+      '@emotion/styled':
+        optional: true
+
   '@mui/x-date-pickers@7.29.4':
     resolution: {integrity: sha512-wJ3tsqk/y6dp+mXGtT9czciAMEO5Zr3IIAHg9x6IL0Eqanqy0N3chbmQQZv3iq0m2qUpQDLvZ4utZBUTJdjNzw==}
     engines: {node: '>=14.0.0'}
@@ -1762,6 +1784,40 @@ packages:
       date-fns-tz: ^3.2.0
       echarts: 5.5.0
       immer: ^10.1.1
+      lodash: ^4.17.21
+      react: ^17.0.2 || ^18.0.0
+      react-dom: ^17.0.2 || ^18.0.0
+      use-resize-observer: ^9.0.0
+
+  '@perses-dev/trace-table-plugin@0.10.0-beta.0':
+    resolution: {integrity: sha512-zTpFRlkFoXr9eN6wzoeANllR+GMDOKGbz5PSunuyiJPVyV4rJu9FuY8vBNPQTmsG0WaTzuiP4N5uXznubspZvg==}
+    peerDependencies:
+      '@emotion/react': ^11.7.1
+      '@emotion/styled': ^11.6.0
+      '@hookform/resolvers': ^3.2.0
+      '@perses-dev/components': ^0.53.0-beta.4
+      '@perses-dev/core': ^0.53.0-beta.3
+      '@perses-dev/plugin-system': ^0.53.0-beta.4
+      date-fns: ^4.1.0
+      date-fns-tz: ^3.2.0
+      echarts: 5.5.0
+      lodash: ^4.17.21
+      react: ^17.0.2 || ^18.0.0
+      react-dom: ^17.0.2 || ^18.0.0
+      use-resize-observer: ^9.0.0
+
+  '@perses-dev/tracing-gantt-chart-plugin@0.12.0-beta.0':
+    resolution: {integrity: sha512-cRDp2DYuUomruAT+m1nEJE8lDR8eXdaVf5CHvB++6QXKBrzCgIiTwJLt+Y1BrS3CHHig3nsW2U9xyGR1L28OfA==}
+    peerDependencies:
+      '@emotion/react': ^11.7.1
+      '@emotion/styled': ^11.6.0
+      '@hookform/resolvers': ^3.2.0
+      '@perses-dev/components': ^0.53.0-beta.4
+      '@perses-dev/core': ^0.53.0-beta.3
+      '@perses-dev/plugin-system': ^0.53.0-beta.4
+      date-fns: ^4.1.0
+      date-fns-tz: ^3.2.0
+      echarts: 5.5.0
       lodash: ^4.17.21
       react: ^17.0.2 || ^18.0.0
       react-dom: ^17.0.2 || ^18.0.0
@@ -5323,6 +5379,9 @@ packages:
     resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
 
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
+
   resize-detector@0.3.0:
     resolution: {integrity: sha512-R/tCuvuOHQ8o2boRP6vgx8hXCCy87H1eY9V5imBYeVNyNVpuL9ciReSccLj2gDcax9+2weXy3bc8Vv+NRXeEvQ==}
 
@@ -7797,6 +7856,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.28
 
+  '@mui/x-data-grid@7.29.12(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mui/system': 6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@mui/utils': 7.3.9(@types/react@18.3.28)(react@18.3.1)
+      '@mui/x-internals': 7.29.0(@types/react@18.3.28)(react@18.3.1)
+      clsx: 2.1.1
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      reselect: 5.1.1
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+
   '@mui/x-date-pickers@7.29.4(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(date-fns@4.1.0)(dayjs@1.11.14)(luxon@3.7.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.28.6
@@ -8392,6 +8470,44 @@ snapshots:
       date-fns-tz: 3.2.0(date-fns@4.1.0)
       echarts: 5.6.0
       immer: 10.2.0
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-resize-observer: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  '@perses-dev/trace-table-plugin@0.10.0-beta.0(zffdvsqjn7tukdqqnp5cqct2nq)':
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@hookform/resolvers': 4.1.3(react-hook-form@7.71.2(react@18.3.1))
+      '@mui/x-data-grid': 7.29.12(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@mui/system@6.5.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@perses-dev/components': 0.53.0-beta.4(j6z42mbiwccbaprd6rlzvg5cje)
+      '@perses-dev/core': 0.53.0-beta.4
+      '@perses-dev/plugin-system': 0.53.0-beta.4(j3zj3rnf3zj4ypnpyryuhhnuym)
+      date-fns: 4.1.0
+      date-fns-tz: 3.2.0(date-fns@4.1.0)
+      echarts: 5.6.0
+      lodash: 4.17.21
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      use-resize-observer: 9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+    transitivePeerDependencies:
+      - '@mui/material'
+      - '@mui/system'
+      - '@types/react'
+
+  '@perses-dev/tracing-gantt-chart-plugin@0.12.0-beta.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1))(@hookform/resolvers@4.1.3(react-hook-form@7.71.2(react@18.3.1)))(@perses-dev/components@0.53.0-beta.4(j6z42mbiwccbaprd6rlzvg5cje))(@perses-dev/core@0.53.0-beta.4)(@perses-dev/plugin-system@0.53.0-beta.4(j3zj3rnf3zj4ypnpyryuhhnuym))(date-fns-tz@3.2.0(date-fns@4.1.0))(date-fns@4.1.0)(echarts@5.6.0)(lodash@4.17.21)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-resize-observer@9.1.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
+    dependencies:
+      '@emotion/react': 11.14.0(@types/react@18.3.28)(react@18.3.1)
+      '@emotion/styled': 11.14.1(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.3.1))(@types/react@18.3.28)(react@18.3.1)
+      '@hookform/resolvers': 4.1.3(react-hook-form@7.71.2(react@18.3.1))
+      '@perses-dev/components': 0.53.0-beta.4(j6z42mbiwccbaprd6rlzvg5cje)
+      '@perses-dev/core': 0.53.0-beta.4
+      '@perses-dev/plugin-system': 0.53.0-beta.4(j3zj3rnf3zj4ypnpyryuhhnuym)
+      color-hash: 2.0.2
+      date-fns: 4.1.0
+      date-fns-tz: 3.2.0(date-fns@4.1.0)
+      echarts: 5.6.0
       lodash: 4.17.21
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -12227,6 +12343,8 @@ snapshots:
   require-from-string@2.0.2: {}
 
   requireindex@1.1.0: {}
+
+  reselect@5.1.1: {}
 
   resize-detector@0.3.0: {}
 

--- a/src/dashboard-main.tsx
+++ b/src/dashboard-main.tsx
@@ -3,11 +3,106 @@ import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { SnackbarProvider } from '@perses-dev/components'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { ReactRouterProvider } from '@perses-dev/plugin-system'
 import Dashboard from '@/perses-dashboard/react/DashboardContainer'
 import { WorkbenchProvider, PersesDashboardFile } from '@/perses-dashboard/react/WorkbenchProvider'
+import {
+  TraceModalPayload,
+  isTraceModalPayload,
+  parseTraceModalPayloadFromHref,
+  TRACE_MODAL_MODE,
+  TRACE_MODAL_SOURCE,
+  TRACE_MODAL_VIEW,
+} from '@/perses-dashboard/traceLink'
+
+function buildTraceGanttFile(payload: TraceModalPayload): PersesDashboardFile {
+  const { traceId, table = 'spans', database } = payload
+  const escapedTraceId = traceId.replace(/'/g, "''")
+  const escapedTable = table.replace(/"/g, '""')
+  const fullTableName = database ? `"${database.replace(/"/g, '""')}"."${escapedTable}"` : `"${escapedTable}"`
+
+  const traceGanttDashboard = {
+    kind: 'Dashboard',
+    metadata: {
+      name: `trace-gantt-${traceId}`,
+      project: 'default',
+      version: 0,
+    },
+    spec: {
+      display: {
+        name: `Trace Gantt - ${traceId}`,
+      },
+      duration: '1h',
+      refreshInterval: '30s',
+      variables: [],
+      layouts: [
+        {
+          kind: 'Grid',
+          spec: {
+            items: [
+              {
+                x: 0,
+                y: 0,
+                width: 24,
+                height: 30,
+                content: {
+                  $ref: '#/spec/panels/traceGanttPanel',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      panels: {
+        traceGanttPanel: {
+          kind: 'Panel',
+          spec: {
+            display: {
+              name: `Trace ${traceId}`,
+            },
+            plugin: {
+              kind: 'TracingGanttChart',
+              spec: {},
+            },
+            queries: [
+              {
+                kind: 'TraceQuery',
+                spec: {
+                  plugin: {
+                    kind: 'GreptimeDBTraceQuery',
+                    spec: {
+                      datasource: {
+                        kind: 'GreptimeDBDatasource',
+                        name: 'sql-default',
+                      },
+                      query: `SELECT * FROM ${fullTableName} WHERE trace_id = '${escapedTraceId}' ORDER BY timestamp ASC`,
+                    },
+                  },
+                },
+              },
+            ],
+          },
+        },
+      },
+      datasources: {},
+    },
+  }
+
+  return {
+    filename: `trace-gantt-${traceId}.json`,
+    content: JSON.stringify(traceGanttDashboard),
+    meta: {
+      commit: {
+        id: 'ephemeral',
+      },
+    },
+  }
+}
 
 function StandaloneApp() {
   const [dashboardData, setDashboardData] = useState<any>(null)
+  const [traceModalPayload, setTraceModalPayload] = useState<TraceModalPayload | null>(null)
+  const [traceModalFile, setTraceModalFile] = useState<PersesDashboardFile | null>(null)
 
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
@@ -30,6 +125,40 @@ function StandaloneApp() {
     return () => window.removeEventListener('message', handleMessage)
   }, [])
 
+  useEffect(() => {
+    const handleDocumentClick = (event: MouseEvent) => {
+      const target = event.target as HTMLElement | null
+      const anchor = target?.closest?.('a') as HTMLAnchorElement | null
+      if (!anchor) return
+
+      const href = anchor.getAttribute('href')
+      if (!href) return
+
+      const payload = parseTraceModalPayloadFromHref(href)
+      if (!payload?.traceId) return
+
+      const normalizedPayload = {
+        ...payload,
+        view: payload.view || TRACE_MODAL_VIEW,
+        mode: payload.mode || TRACE_MODAL_MODE,
+        source: payload.source || TRACE_MODAL_SOURCE,
+      }
+
+      // Only intercept when link explicitly opts into modal mode.
+      if (payload.mode !== TRACE_MODAL_MODE) return
+
+      if (!isTraceModalPayload(normalizedPayload)) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      setTraceModalPayload(normalizedPayload)
+      setTraceModalFile(buildTraceGanttFile(normalizedPayload))
+    }
+
+    document.addEventListener('click', handleDocumentClick, true)
+    return () => document.removeEventListener('click', handleDocumentClick, true)
+  }, [])
+
   if (!dashboardData) {
     return (
       <div
@@ -48,6 +177,12 @@ function StandaloneApp() {
   }
 
   const { file } = dashboardData as { file: PersesDashboardFile }
+  const modalTraceId = traceModalPayload?.traceId || ''
+  const modalDatabase = traceModalPayload?.database || dashboardData.database || ''
+  const closeTraceModal = () => {
+    setTraceModalPayload(null)
+    setTraceModalFile(null)
+  }
 
   return (
     <SnackbarProvider anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}>
@@ -61,9 +196,71 @@ function StandaloneApp() {
         instance={dashboardData.instance || ''}
       >
         <BrowserRouter>
-          <Routes>
-            <Route path="*" element={<Dashboard dashboardEditable={dashboardData.dashboardEditable} />} />
-          </Routes>
+          <ReactRouterProvider>
+            <Routes>
+              <Route path="*" element={<Dashboard dashboardEditable={dashboardData.dashboardEditable} />} />
+            </Routes>
+            {traceModalPayload && traceModalFile ? (
+              <div
+                style={{
+                  position: 'fixed',
+                  top: 0,
+                  right: 0,
+                  height: '100vh',
+                  width: 'min(1200px, 78vw)',
+                  minWidth: '720px',
+                  zIndex: 1300,
+                  background: '#fff',
+                  borderLeft: '1px solid #e5e7eb',
+                  boxShadow: '-8px 0 24px rgba(0, 0, 0, 0.12)',
+                  display: 'flex',
+                  flexDirection: 'column',
+                }}
+              >
+                <div
+                  style={{
+                    height: '48px',
+                    borderBottom: '1px solid #f0f0f0',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                    padding: '0 12px',
+                    fontSize: '14px',
+                    fontWeight: 600,
+                    flexShrink: 0,
+                  }}
+                >
+                  <span>{`Trace Gantt - ${modalTraceId}`}</span>
+                  <button
+                    type="button"
+                    onClick={closeTraceModal}
+                    style={{
+                      border: 'none',
+                      background: 'transparent',
+                      cursor: 'pointer',
+                      fontSize: '16px',
+                      lineHeight: 1,
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+                <div style={{ flex: 1, minHeight: 0 }}>
+                  <WorkbenchProvider
+                    database={modalDatabase}
+                    username={dashboardData.username || ''}
+                    password={dashboardData.password || ''}
+                    authHeader={dashboardData.authHeader || 'Authorization'}
+                    name={traceModalFile.filename}
+                    file={traceModalFile}
+                    instance={dashboardData.instance || ''}
+                  >
+                    <Dashboard dashboardEditable={false} />
+                  </WorkbenchProvider>
+                </div>
+              </div>
+            ) : null}
+          </ReactRouterProvider>
         </BrowserRouter>
       </WorkbenchProvider>
     </SnackbarProvider>

--- a/src/dashboard-main.tsx
+++ b/src/dashboard-main.tsx
@@ -106,6 +106,11 @@ function StandaloneApp() {
   const [traceModalPayload, setTraceModalPayload] = useState<TraceModalPayload | null>(null)
   const [traceModalFile, setTraceModalFile] = useState<PersesDashboardFile | null>(null)
 
+  const isUnresolvedTemplateValue = (value?: string): boolean => {
+    if (!value) return true
+    return /^\$\{[^}]+\}$/.test(value.trim())
+  }
+
   useEffect(() => {
     const handleMessage = (event: MessageEvent) => {
       if (event.data && event.data.type === 'update-dashboard') {
@@ -160,6 +165,10 @@ function StandaloneApp() {
       if (payload.mode !== TRACE_MODAL_MODE) return
 
       if (!isTraceModalPayload(normalizedPayload)) return
+
+      // Skip opening side view when table/database variables are still unresolved templates.
+      if (isUnresolvedTemplateValue(normalizedPayload.table)) return
+      if (normalizedPayload.database && isUnresolvedTemplateValue(normalizedPayload.database)) return
 
       event.preventDefault()
       event.stopPropagation()

--- a/src/dashboard-main.tsx
+++ b/src/dashboard-main.tsx
@@ -213,6 +213,7 @@ function StandaloneApp() {
             </Routes>
             {traceModalPayload && traceModalFile ? (
               <div
+                className="trace-gantt-sidepanel"
                 style={{
                   position: 'fixed',
                   top: 0,

--- a/src/dashboard-main.tsx
+++ b/src/dashboard-main.tsx
@@ -2,6 +2,7 @@ import '@/perses-dashboard/react/app.css'
 import React, { useEffect, useState } from 'react'
 import ReactDOM from 'react-dom/client'
 import { SnackbarProvider } from '@perses-dev/components'
+import Drawer from '@mui/material/Drawer'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { ReactRouterProvider } from '@perses-dev/plugin-system'
 import Dashboard from '@/perses-dashboard/react/DashboardContainer'
@@ -211,67 +212,69 @@ function StandaloneApp() {
             <Routes>
               <Route path="*" element={<Dashboard dashboardEditable={dashboardData.dashboardEditable} />} />
             </Routes>
-            {traceModalPayload && traceModalFile ? (
-              <div
-                className="trace-gantt-sidepanel"
-                style={{
-                  position: 'fixed',
-                  top: 0,
-                  right: 0,
-                  height: '100vh',
-                  width: 'min(1200px, 78vw)',
-                  minWidth: '720px',
-                  zIndex: 1300,
-                  background: '#fff',
+            <Drawer
+              className="trace-gantt-sidepanel"
+              anchor="right"
+              open={Boolean(traceModalPayload && traceModalFile)}
+              onClose={closeTraceModal}
+              ModalProps={{ keepMounted: true }}
+              PaperProps={{
+                sx: {
+                  width: '80vw',
+                  maxWidth: '100vw',
                   borderLeft: '1px solid #e5e7eb',
                   boxShadow: '-8px 0 24px rgba(0, 0, 0, 0.12)',
                   display: 'flex',
                   flexDirection: 'column',
-                }}
-              >
-                <div
-                  style={{
-                    height: '48px',
-                    borderBottom: '1px solid #f0f0f0',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'space-between',
-                    padding: '0 12px',
-                    fontSize: '14px',
-                    fontWeight: 600,
-                    flexShrink: 0,
-                  }}
-                >
-                  <span>{`Trace Gantt - ${modalTraceId}`}</span>
-                  <button
-                    type="button"
-                    onClick={closeTraceModal}
+                },
+              }}
+            >
+              {traceModalPayload && traceModalFile ? (
+                <>
+                  <div
                     style={{
-                      border: 'none',
-                      background: 'transparent',
-                      cursor: 'pointer',
-                      fontSize: '16px',
-                      lineHeight: 1,
+                      height: '48px',
+                      borderBottom: '1px solid #f0f0f0',
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      padding: '0 12px',
+                      fontSize: '14px',
+                      fontWeight: 600,
+                      flexShrink: 0,
                     }}
                   >
-                    ×
-                  </button>
-                </div>
-                <div style={{ flex: 1, minHeight: 0 }}>
-                  <WorkbenchProvider
-                    database={modalDatabase}
-                    username={dashboardData.username || ''}
-                    password={dashboardData.password || ''}
-                    authHeader={dashboardData.authHeader || 'Authorization'}
-                    name={traceModalFile.filename}
-                    file={traceModalFile}
-                    instance={dashboardData.instance || ''}
-                  >
-                    <Dashboard dashboardEditable={false} controlEditableBodyClass={false} />
-                  </WorkbenchProvider>
-                </div>
-              </div>
-            ) : null}
+                    <span>{`Trace Gantt - ${modalTraceId}`}</span>
+                    <button
+                      type="button"
+                      onClick={closeTraceModal}
+                      style={{
+                        border: 'none',
+                        background: 'transparent',
+                        cursor: 'pointer',
+                        fontSize: '16px',
+                        lineHeight: 1,
+                      }}
+                    >
+                      ×
+                    </button>
+                  </div>
+                  <div style={{ flex: 1, minHeight: 0 }}>
+                    <WorkbenchProvider
+                      database={modalDatabase}
+                      username={dashboardData.username || ''}
+                      password={dashboardData.password || ''}
+                      authHeader={dashboardData.authHeader || 'Authorization'}
+                      name={traceModalFile.filename}
+                      file={traceModalFile}
+                      instance={dashboardData.instance || ''}
+                    >
+                      <Dashboard dashboardEditable={false} controlEditableBodyClass={false} />
+                    </WorkbenchProvider>
+                  </div>
+                </>
+              ) : null}
+            </Drawer>
           </ReactRouterProvider>
         </BrowserRouter>
       </WorkbenchProvider>

--- a/src/dashboard-main.tsx
+++ b/src/dashboard-main.tsx
@@ -10,6 +10,7 @@ import {
   TraceModalPayload,
   isTraceModalPayload,
   parseTraceModalPayloadFromHref,
+  TRACE_MODAL_LINK_PATH,
   TRACE_MODAL_MODE,
   TRACE_MODAL_SOURCE,
   TRACE_MODAL_VIEW,
@@ -134,6 +135,16 @@ function StandaloneApp() {
       const href = anchor.getAttribute('href')
       if (!href) return
 
+      let url: URL
+      try {
+        url = new URL(href, window.location.origin)
+      } catch {
+        return
+      }
+
+      // Intercept only our modal protocol path.
+      if (url.pathname !== TRACE_MODAL_LINK_PATH) return
+
       const payload = parseTraceModalPayloadFromHref(href)
       if (!payload?.traceId) return
 
@@ -255,7 +266,7 @@ function StandaloneApp() {
                     file={traceModalFile}
                     instance={dashboardData.instance || ''}
                   >
-                    <Dashboard dashboardEditable={false} />
+                    <Dashboard dashboardEditable={false} controlEditableBodyClass={false} />
                   </WorkbenchProvider>
                 </div>
               </div>

--- a/src/perses-dashboard/react/Dashboard.styles.ts
+++ b/src/perses-dashboard/react/Dashboard.styles.ts
@@ -11,7 +11,7 @@ export const DASHBOARD_TOKENS = {
     textMuted: '#64748b',
     divider: '#f1f5f9',
     dividerDark: '#e2e8f0',
-    background: 'oklch(0.99 0 0)',
+    background: '#fcfcfc',
     paper: '#ffffff',
     noData: '#64748b',
   },

--- a/src/perses-dashboard/react/DashboardContainer.tsx
+++ b/src/perses-dashboard/react/DashboardContainer.tsx
@@ -13,6 +13,7 @@ import { ReactRouter6Adapter } from 'use-query-params/adapters/react-router-6'
 import HelperDashboardView from './DashboardView'
 import { useWorkbenchContext } from './WorkbenchProvider'
 import { DASHBOARD_TOKENS, globalStyles } from './Dashboard.styles'
+import { ensureTraceTableLinks } from '../traceLink'
 
 interface DashboardProps {
   dashboardEditable?: boolean
@@ -270,6 +271,7 @@ export default function Dashboard(props: DashboardProps = {}) {
     async (dashboardJSON: DashboardResource | EphemeralDashboardResource): Promise<boolean> => {
       return new Promise((resolve, reject) => {
         const requestId = `save-${Date.now()}-${Math.random()}`
+        const normalizedDashboardJSON = dashboardJSON
 
         const handleMessage = (event: MessageEvent) => {
           if (event.data.type === 'save-dashboard-response' && event.data.requestId === requestId) {
@@ -290,7 +292,7 @@ export default function Dashboard(props: DashboardProps = {}) {
               type: 'save-dashboard-request',
               requestId,
               data: {
-                dashboardJSON,
+                dashboardJSON: normalizedDashboardJSON,
                 name,
                 commitId: file.meta?.commit?.id || '',
               },
@@ -331,7 +333,7 @@ export default function Dashboard(props: DashboardProps = {}) {
 
   let data: DashboardResource | EphemeralDashboardResource
   try {
-    data = JSON.parse(file.content) || INIT_DATA
+    data = ensureTraceTableLinks(JSON.parse(file.content) || INIT_DATA)
 
     if (data.spec?.panels) {
       Object.values(data.spec.panels).forEach((panel: any) => {

--- a/src/perses-dashboard/react/DashboardContainer.tsx
+++ b/src/perses-dashboard/react/DashboardContainer.tsx
@@ -17,13 +17,16 @@ import { ensureTraceTableLinks } from '../traceLink'
 
 interface DashboardProps {
   dashboardEditable?: boolean
+  controlEditableBodyClass?: boolean
 }
 
 export default function Dashboard(props: DashboardProps = {}) {
   const { name, file } = useWorkbenchContext()
   const dashboardEditable = props.dashboardEditable ?? false
+  const controlEditableBodyClass = props.controlEditableBodyClass ?? true
 
   React.useEffect(() => {
+    if (!controlEditableBodyClass) return undefined
     const { body } = document
     if (dashboardEditable) {
       body.classList.add('dashboard-editable')
@@ -33,7 +36,7 @@ export default function Dashboard(props: DashboardProps = {}) {
     return () => {
       body.classList.remove('dashboard-editable')
     }
-  }, [dashboardEditable])
+  }, [dashboardEditable, controlEditableBodyClass])
 
   React.useEffect(() => {
     let patched = false

--- a/src/perses-dashboard/react/DashboardContainer.tsx
+++ b/src/perses-dashboard/react/DashboardContainer.tsx
@@ -24,6 +24,7 @@ export default function Dashboard(props: DashboardProps = {}) {
   const { name, file } = useWorkbenchContext()
   const dashboardEditable = props.dashboardEditable ?? false
   const controlEditableBodyClass = props.controlEditableBodyClass ?? true
+  const [saveRefreshToken, setSaveRefreshToken] = React.useState(0)
 
   React.useEffect(() => {
     if (!controlEditableBodyClass) return undefined
@@ -274,12 +275,13 @@ export default function Dashboard(props: DashboardProps = {}) {
     async (dashboardJSON: DashboardResource | EphemeralDashboardResource): Promise<boolean> => {
       return new Promise((resolve, reject) => {
         const requestId = `save-${Date.now()}-${Math.random()}`
-        const normalizedDashboardJSON = dashboardJSON
+        const normalizedDashboardJSON = ensureTraceTableLinks(dashboardJSON)
 
         const handleMessage = (event: MessageEvent) => {
           if (event.data.type === 'save-dashboard-response' && event.data.requestId === requestId) {
             window.removeEventListener('message', handleMessage)
             if (event.data.success) {
+              setSaveRefreshToken((prev) => prev + 1)
               resolve(true)
             } else {
               reject(new Error(event.data.error || 'Save failed'))
@@ -370,6 +372,7 @@ export default function Dashboard(props: DashboardProps = {}) {
           <ChartsProvider chartsTheme={chartsTheme}>
             <style>{globalStyles}</style>
             <HelperDashboardView
+              key={`${data.metadata.name}-${saveRefreshToken}`}
               dashboardResource={data}
               onSave={save}
               isReadonly={!dashboardEditable}

--- a/src/perses-dashboard/react/app.css
+++ b/src/perses-dashboard/react/app.css
@@ -34,3 +34,8 @@ main,
 [data-testid='dashboard-toolbar'] > .MuiBox-root:nth-child(2) {
   width: auto !important;
 }
+
+/* Keep trace side panel visually focused on gantt content only. */
+.trace-gantt-sidepanel [data-testid='dashboard-toolbar'] {
+  display: none !important;
+}

--- a/src/perses-dashboard/react/plugin.ts
+++ b/src/perses-dashboard/react/plugin.ts
@@ -3,6 +3,8 @@ import * as logsTablePlugin from '@perses-dev/logs-table-plugin'
 import * as prometheusPlugin from '@perses-dev/prometheus-plugin'
 import * as statChartPlugin from '@perses-dev/stat-chart-plugin'
 import * as tablePlugin from '@perses-dev/table-plugin'
+import * as tracingGanttChartPlugin from '@perses-dev/tracing-gantt-chart-plugin'
+import * as traceTablePlugin from '@perses-dev/trace-table-plugin'
 import * as timeseriesChartPlugin from '@perses-dev/timeseries-chart-plugin'
 import * as greptimedbPlugin from '@perses-dev/greptimedb-plugin'
 import { PluginLoader, PluginModuleResource, dynamicImportPluginLoader } from '@perses-dev/plugin-system'
@@ -27,6 +29,14 @@ const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
   {
     resource: tablePlugin.getPluginModule() as PluginModuleResource,
     importPlugin: () => Promise.resolve(tablePlugin),
+  },
+  {
+    resource: traceTablePlugin.getPluginModule() as PluginModuleResource,
+    importPlugin: () => Promise.resolve(traceTablePlugin),
+  },
+  {
+    resource: tracingGanttChartPlugin.getPluginModule() as PluginModuleResource,
+    importPlugin: () => Promise.resolve(tracingGanttChartPlugin),
   },
   {
     resource: timeseriesChartPlugin.getPluginModule() as PluginModuleResource,

--- a/src/perses-dashboard/react/plugin.ts
+++ b/src/perses-dashboard/react/plugin.ts
@@ -8,6 +8,25 @@ import * as traceTablePlugin from '@perses-dev/trace-table-plugin'
 import * as timeseriesChartPlugin from '@perses-dev/timeseries-chart-plugin'
 import * as greptimedbPlugin from '@perses-dev/greptimedb-plugin'
 import { PluginLoader, PluginModuleResource, dynamicImportPluginLoader } from '@perses-dev/plugin-system'
+import { buildDefaultTraceLink } from '../traceLink'
+
+const patchedTraceTablePlugin = {
+  ...traceTablePlugin,
+  TraceTable: {
+    ...(traceTablePlugin as any).TraceTable,
+    createInitialOptions: () => {
+      const baseOptions = (traceTablePlugin as any).TraceTable?.createInitialOptions?.() || {}
+      const traceLink = buildDefaultTraceLink()
+      return {
+        ...baseOptions,
+        links: {
+          ...(baseOptions.links || {}),
+          trace: baseOptions.links?.trace || traceLink,
+        },
+      }
+    },
+  },
+}
 
 const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
   {
@@ -32,7 +51,7 @@ const bundledPluginLoader: PluginLoader = dynamicImportPluginLoader([
   },
   {
     resource: traceTablePlugin.getPluginModule() as PluginModuleResource,
-    importPlugin: () => Promise.resolve(traceTablePlugin),
+    importPlugin: () => Promise.resolve(patchedTraceTablePlugin as any),
   },
   {
     resource: tracingGanttChartPlugin.getPluginModule() as PluginModuleResource,

--- a/src/perses-dashboard/traceLink.ts
+++ b/src/perses-dashboard/traceLink.ts
@@ -1,0 +1,87 @@
+export const TRACE_MODAL_VIEW = 'gantt'
+export const TRACE_MODAL_MODE = 'modal'
+export const TRACE_MODAL_SOURCE = 'perses-trace-table'
+export const TRACE_ID_QUERY_KEY = 'traceId'
+
+export type TraceModalPayload = {
+  traceId: string
+  table?: string
+  database?: string
+  source?: string
+  mode?: string
+  view?: string
+}
+
+export function buildDefaultTraceLink(): string {
+  return `/dashboard/traces?${TRACE_ID_QUERY_KEY}=\${traceId}&table=\${table}&database=\${database}&view=${TRACE_MODAL_VIEW}&mode=${TRACE_MODAL_MODE}&source=${TRACE_MODAL_SOURCE}`
+}
+
+export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: T): T {
+  if (!dashboard?.spec?.panels) return dashboard
+
+  const nextPanels = { ...dashboard.spec.panels }
+  let hasChanges = false
+
+  Object.entries(nextPanels).forEach(([panelId, panel]: [string, any]) => {
+    if (panel?.kind !== 'Panel') return
+    if (panel?.spec?.plugin?.kind !== 'TraceTable') return
+
+    const currentTraceLink = panel?.spec?.plugin?.spec?.links?.trace
+    if (typeof currentTraceLink === 'string' && currentTraceLink.trim().length > 0) return
+
+    nextPanels[panelId] = {
+      ...panel,
+      spec: {
+        ...panel.spec,
+        plugin: {
+          ...panel.spec?.plugin,
+          spec: {
+            ...(panel.spec?.plugin?.spec || {}),
+            links: {
+              ...(panel.spec?.plugin?.spec?.links || {}),
+              trace: buildDefaultTraceLink(),
+            },
+          },
+        },
+      },
+    }
+    hasChanges = true
+  })
+
+  if (!hasChanges) return dashboard
+
+  return {
+    ...dashboard,
+    spec: {
+      ...dashboard.spec,
+      panels: nextPanels,
+    },
+  }
+}
+
+export function parseTraceModalPayloadFromHref(href: string): TraceModalPayload | null {
+  if (!href) return null
+
+  let url: URL
+  try {
+    url = new URL(href, window.location.origin)
+  } catch {
+    return null
+  }
+
+  const traceId = url.searchParams.get(TRACE_ID_QUERY_KEY) || url.searchParams.get('var-traceId')
+  if (!traceId) return null
+
+  return {
+    traceId,
+    view: url.searchParams.get('view') || undefined,
+    mode: url.searchParams.get('mode') || undefined,
+    source: url.searchParams.get('source') || undefined,
+    table: url.searchParams.get('table') || url.searchParams.get('var-table') || undefined,
+    database: url.searchParams.get('database') || url.searchParams.get('var-database') || undefined,
+  }
+}
+
+export function isTraceModalPayload(payload: TraceModalPayload): boolean {
+  return payload.mode === TRACE_MODAL_MODE && payload.view === TRACE_MODAL_VIEW && Boolean(payload.traceId)
+}

--- a/src/perses-dashboard/traceLink.ts
+++ b/src/perses-dashboard/traceLink.ts
@@ -69,6 +69,39 @@ function resolveTraceTargetFromSql(sql?: string): TraceLinkContext {
   return { table, database }
 }
 
+function isTemplateValue(value?: string | null): boolean {
+  if (!value) return false
+  const trimmed = value.trim()
+  return /^\$\{[^}]+\}$/.test(trimmed) || /^%24%7B[^%]+%7D$/i.test(trimmed)
+}
+
+function shouldAutoUpgradeTraceLink(currentTraceLink?: string): boolean {
+  if (!currentTraceLink || currentTraceLink.trim().length === 0) return true
+
+  let url: URL
+  try {
+    url = new URL(currentTraceLink, window.location.origin)
+  } catch {
+    return false
+  }
+
+  const tableParam = url.searchParams.get('table')
+  const databaseParam = url.searchParams.get('database')
+  const modeParam = url.searchParams.get('mode')
+  const viewParam = url.searchParams.get('view')
+  const sourceParam = url.searchParams.get('source')
+
+  const isKnownTraceModalLink =
+    url.pathname === TRACE_MODAL_LINK_PATH ||
+    (modeParam === TRACE_MODAL_MODE && viewParam === TRACE_MODAL_VIEW) ||
+    sourceParam === TRACE_MODAL_SOURCE
+
+  if (!isKnownTraceModalLink) return false
+
+  // Auto-upgrade protocol links that still carry unresolved templates.
+  return isTemplateValue(tableParam) || isTemplateValue(databaseParam)
+}
+
 export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: T): T {
   if (!dashboard?.spec?.panels) return dashboard
 
@@ -82,18 +115,8 @@ export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: 
     const resolvedTarget = resolveTraceTargetFromSql(extractSqlFromTraceTablePanel(panel))
     const currentTraceLink = panel?.spec?.plugin?.spec?.links?.trace
     const inferredTraceLink = buildDefaultTraceLink(resolvedTarget)
-    const currentIsPresetDefault =
-      typeof currentTraceLink === 'string' &&
-      (currentTraceLink === buildDefaultTraceLink() ||
-        currentTraceLink === buildDefaultTraceLink({ table: resolvedTarget.table }))
-
-    // Keep user custom links untouched; only inject/upgrade default-generated links.
-    if (
-      typeof currentTraceLink === 'string' &&
-      currentTraceLink.trim().length > 0 &&
-      !currentIsPresetDefault &&
-      currentTraceLink !== inferredTraceLink
-    ) {
+    // Keep user custom links untouched; auto-upgrade only empty/default protocol links.
+    if (!shouldAutoUpgradeTraceLink(currentTraceLink) && currentTraceLink !== inferredTraceLink) {
       return
     }
 

--- a/src/perses-dashboard/traceLink.ts
+++ b/src/perses-dashboard/traceLink.ts
@@ -2,6 +2,7 @@ export const TRACE_MODAL_VIEW = 'gantt'
 export const TRACE_MODAL_MODE = 'modal'
 export const TRACE_MODAL_SOURCE = 'perses-trace-table'
 export const TRACE_ID_QUERY_KEY = 'traceId'
+export const TRACE_MODAL_LINK_PATH = '/__perses_trace_modal__'
 
 export type TraceModalPayload = {
   traceId: string
@@ -12,8 +13,60 @@ export type TraceModalPayload = {
   view?: string
 }
 
-export function buildDefaultTraceLink(): string {
-  return `/dashboard/traces?${TRACE_ID_QUERY_KEY}=\${traceId}&table=\${table}&database=\${database}&view=${TRACE_MODAL_VIEW}&mode=${TRACE_MODAL_MODE}&source=${TRACE_MODAL_SOURCE}`
+type TraceLinkContext = {
+  table?: string
+  database?: string
+}
+
+const TRACE_ID_TEMPLATE = ['$', '{traceId}'].join('')
+const TABLE_TEMPLATE = ['$', '{table}'].join('')
+const DATABASE_TEMPLATE = ['$', '{database}'].join('')
+
+export function buildDefaultTraceLink(context: TraceLinkContext = {}): string {
+  const params: Array<[string, string]> = []
+  params.push([TRACE_ID_QUERY_KEY, TRACE_ID_TEMPLATE])
+  params.push(['table', context.table || TABLE_TEMPLATE])
+  if (context.database) {
+    params.push(['database', context.database])
+  } else if (!context.table) {
+    // Keep backward-compatible variable template when table/database are not resolved yet.
+    params.push(['database', DATABASE_TEMPLATE])
+  }
+  params.push(['view', TRACE_MODAL_VIEW])
+  params.push(['mode', TRACE_MODAL_MODE])
+  params.push(['source', TRACE_MODAL_SOURCE])
+
+  const query = params
+    .map(([key, value]) => {
+      const encodedValue = value.startsWith('${') && value.endsWith('}') ? value : encodeURIComponent(value)
+      return `${encodeURIComponent(key)}=${encodedValue}`
+    })
+    .join('&')
+
+  return `${TRACE_MODAL_LINK_PATH}?${query}`
+}
+
+function extractSqlFromTraceTablePanel(panel: any): string | undefined {
+  const queries = panel?.spec?.queries
+  if (!Array.isArray(queries)) return undefined
+  return queries
+    .map((query: any) => query?.spec?.plugin?.spec?.query)
+    .find((sql: unknown) => typeof sql === 'string' && sql.trim().length > 0)
+}
+
+function resolveTraceTargetFromSql(sql?: string): TraceLinkContext {
+  if (!sql) return {}
+  // Handles: FROM "db"."table", FROM db.table, FROM "table", FROM table
+  const fromMatch = sql.match(
+    /\bfrom\s+((?:"[^"]+"|`[^`]+`|[a-zA-Z_][\w$]*)\s*\.\s*)?(?:"([^"]+)"|`([^`]+)`|([a-zA-Z_][\w$]*))/i
+  )
+  if (!fromMatch) return {}
+
+  const rawDatabasePart = fromMatch[1]?.replace(/\s*\.\s*$/, '').trim()
+  const database = rawDatabasePart ? rawDatabasePart.replace(/^["`]|["`]$/g, '') : undefined
+  const table = fromMatch[2] || fromMatch[3] || fromMatch[4]
+  if (!table) return {}
+  return { table, database }
 }
 
 export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: T): T {
@@ -26,8 +79,23 @@ export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: 
     if (panel?.kind !== 'Panel') return
     if (panel?.spec?.plugin?.kind !== 'TraceTable') return
 
+    const resolvedTarget = resolveTraceTargetFromSql(extractSqlFromTraceTablePanel(panel))
     const currentTraceLink = panel?.spec?.plugin?.spec?.links?.trace
-    if (typeof currentTraceLink === 'string' && currentTraceLink.trim().length > 0) return
+    const inferredTraceLink = buildDefaultTraceLink(resolvedTarget)
+    const currentIsPresetDefault =
+      typeof currentTraceLink === 'string' &&
+      (currentTraceLink === buildDefaultTraceLink() ||
+        currentTraceLink === buildDefaultTraceLink({ table: resolvedTarget.table }))
+
+    // Keep user custom links untouched; only inject/upgrade default-generated links.
+    if (
+      typeof currentTraceLink === 'string' &&
+      currentTraceLink.trim().length > 0 &&
+      !currentIsPresetDefault &&
+      currentTraceLink !== inferredTraceLink
+    ) {
+      return
+    }
 
     nextPanels[panelId] = {
       ...panel,
@@ -39,7 +107,7 @@ export function ensureTraceTableLinks<T extends Record<string, any>>(dashboard: 
             ...(panel.spec?.plugin?.spec || {}),
             links: {
               ...(panel.spec?.plugin?.spec?.links || {}),
-              trace: buildDefaultTraceLink(),
+              trace: inferredTraceLink,
             },
           },
         },


### PR DESCRIPTION
support trace list and detail trace view in perses
add a sql query in trace table panel, just one step to show trace table and trace gannt view.
the perses dashboard integration code will automatic set the trace link column,and make a trace detail query.


<img width="1101" height="921" alt="image" src="https://github.com/user-attachments/assets/28d2c769-6dba-40d9-8295-0947ee2f9d6b" />
<img width="2205" height="1095" alt="image" src="https://github.com/user-attachments/assets/92498402-f574-43c5-9df1-2d17cd5c4117" />
